### PR TITLE
fix(react-board): react 17, cleanup stage element when render failed outside safe render

### DIFF
--- a/packages/react-board/src/react-error-handled-render.tsx
+++ b/packages/react-board/src/react-error-handled-render.tsx
@@ -30,9 +30,10 @@ export const reactErrorHandledRendering = async (element: React.ReactElement, co
             });
         } catch (e) {
             /**
-             * only in case of react 17 error during render that rejects promise above
-             * will leave container DOM node with corrupted react object attached to it in _reactRootContainer
-             * this will result in empty renders even when render function does not fail
+             * If an error occurs during ReactDOM.render(), React 17 will keep
+             * _reactRootContainer property attached to the container DOM node.
+             * This property points to an a stale fiber object, which prevents
+             * subsequent ReactDOM.render() calls from working.
              * issue https://github.com/wixplosives/codux/issues/12211
              * In case of such error we need to cleanup container DOM node
              */

--- a/packages/react-board/src/react-error-handled-render.tsx
+++ b/packages/react-board/src/react-error-handled-render.tsx
@@ -34,8 +34,6 @@ export const reactErrorHandledRendering = async (element: React.ReactElement, co
              * _reactRootContainer property attached to the container DOM node.
              * This property points to an a stale fiber object, which prevents
              * subsequent ReactDOM.render() calls from working.
-             * issue https://github.com/wixplosives/codux/issues/12211
-             * In case of such error we need to cleanup container DOM node
              */
             cleanup();
             throw e;


### PR DESCRIPTION
related https://github.com/wixplosives/codux/issues/12211

When render fails and error cannot be intercepted with safe render it will throw error and renderer will never provide cleanup function for container `() => ReactDOM.unmountComponentAtNode(container)`. Only in React@17 broken render will leave internal _reactRootContainer object on container DOM node that will  result into empty renders (see videos from the issue).
React@18 does not have this issue.

Fix: clean up container node when such error occurs.



https://user-images.githubusercontent.com/9338713/211033885-f9d30cc5-bd91-4020-9873-a0cae43f51d3.mov



Note: I tried to figure out implementation intent here with error boundary and rejecting the promise as much as I could. I implemented the fix in a way that it does not change the behaviour of the function. But I'm not sure I completely understand why we catch the error with boundary then reject promise immediately 