### PR TITLE
fix(react-board): error handling in react@18

### DIFF
--- a/packages/react-board/test/error-handling.spec.ts
+++ b/packages/react-board/test/error-handling.spec.ts
@@ -6,9 +6,10 @@ import chai, { expect } from 'chai';
 
 chai.use(chaiAsPromised);
 
-const dismissEvent = (event: Event) => event.preventDefault();
-
 describe('Board.render() error handling', () => {
+    // We want to prevent the default behavior of the error event, which makes the tests fail.
+    const dismissEvent = (event: Event) => event.preventDefault();
+
     // Mocha has its own error handler that traps unhandled exceptions.
     // We want to disable it for this test suite in order to test the error handling of create board.
     let globalMochaErrorHandler: OnErrorEventHandler = null;

--- a/packages/react-board/test/error-handling.spec.ts
+++ b/packages/react-board/test/error-handling.spec.ts
@@ -6,15 +6,21 @@ import chai, { expect } from 'chai';
 
 chai.use(chaiAsPromised);
 
+function errorHandler(event: ErrorEvent) {
+    event.preventDefault();
+}
+
 describe('create board error handling', () => {
     // Mocha has its own error handler that traps unhandled exceptions.
     // We want to disable it for this test suite in order to test the error handling of create board.
     let globalMochaErrorHandler: OnErrorEventHandler = null;
     before(() => {
+        globalThis.addEventListener('error', errorHandler);
         globalMochaErrorHandler = window.onerror;
         window.onerror = null;
     });
     after(() => {
+        globalThis.removeEventListener('error', errorHandler);
         window.onerror = globalMochaErrorHandler;
         globalMochaErrorHandler = null;
     });

--- a/packages/react-board/test/error-handling.spec.ts
+++ b/packages/react-board/test/error-handling.spec.ts
@@ -6,21 +6,19 @@ import chai, { expect } from 'chai';
 
 chai.use(chaiAsPromised);
 
-function errorHandler(event: ErrorEvent) {
-    event.preventDefault();
-}
+const dismissEvent = (event: Event) => event.preventDefault();
 
-describe('create board error handling', () => {
+describe('Board.render() error handling', () => {
     // Mocha has its own error handler that traps unhandled exceptions.
     // We want to disable it for this test suite in order to test the error handling of create board.
     let globalMochaErrorHandler: OnErrorEventHandler = null;
     before(() => {
-        globalThis.addEventListener('error', errorHandler);
+        globalThis.addEventListener('error', dismissEvent);
         globalMochaErrorHandler = window.onerror;
         window.onerror = null;
     });
     after(() => {
-        globalThis.removeEventListener('error', errorHandler);
+        globalThis.removeEventListener('error', dismissEvent);
         window.onerror = globalMochaErrorHandler;
         globalMochaErrorHandler = null;
     });
@@ -39,8 +37,6 @@ describe('create board error handling', () => {
         disposables.add(cleanup);
         const cleanupRender = await throwingOnRerenderBoard.render(canvas);
         disposables.add(cleanupRender);
-
-        document.getElementById('divId')?.click();
-        await expect(throwingOnRerenderBoard.render(canvas)).to.be.rejectedWith('ref.current.map is not a function');
+        await expect(throwingOnRerenderBoard.render(canvas)).to.be.rejectedWith('Intentional Error on re-render');
     });
 });

--- a/packages/react-board/test/error-handling.spec.ts
+++ b/packages/react-board/test/error-handling.spec.ts
@@ -1,0 +1,40 @@
+import { createDisposables } from '@wixc3/create-disposables';
+import throwingOnMountBoard from './fixtures/throwing.board';
+import throwingOnRerenderBoard from './fixtures/throwing-on-click.board';
+import chaiAsPromised from 'chai-as-promised';
+import chai, { expect } from 'chai';
+
+chai.use(chaiAsPromised);
+
+describe('create board error handling', () => {
+    // Mocha has its own error handler that traps unhandled exceptions.
+    // We want to disable it for this test suite in order to test the error handling of create board.
+    let globalMochaErrorHandler: OnErrorEventHandler = null;
+    before(() => {
+        globalMochaErrorHandler = window.onerror;
+        window.onerror = null;
+    });
+    after(() => {
+        window.onerror = globalMochaErrorHandler;
+        globalMochaErrorHandler = null;
+    });
+
+    const disposables = createDisposables();
+    afterEach(disposables.dispose);
+
+    it(`rejects if the rendered component throws an error on mount`, async () => {
+        const { canvas, cleanup } = throwingOnMountBoard.setupStage();
+        disposables.add(cleanup);
+        await expect(throwingOnMountBoard.render(canvas)).to.be.rejectedWith('Intentional Mount Error');
+    });
+
+    it(`rejects if the rendered component throws an error on rerender`, async () => {
+        const { canvas, cleanup } = throwingOnRerenderBoard.setupStage();
+        disposables.add(cleanup);
+        const cleanupRender = await throwingOnRerenderBoard.render(canvas);
+        disposables.add(cleanupRender);
+
+        document.getElementById('divId')?.click();
+        await expect(throwingOnRerenderBoard.render(canvas)).to.be.rejectedWith('ref.current.map is not a function');
+    });
+});

--- a/packages/react-board/test/fixtures/throwing-on-click.board.tsx
+++ b/packages/react-board/test/fixtures/throwing-on-click.board.tsx
@@ -4,11 +4,11 @@ import React from 'react';
 export default createBoard({
     name: 'Throwing On Click Board',
     Board: () => {
-        const ref = React.useRef([1, 2, 3]);
-        return (
-            <div id="divId" onClick={() => ((ref.current as unknown as string) = 'not array')}>
-                {ref.current.map((item) => item)}
-            </div>
-        );
+        const renderCount = React.useRef(1);
+        if (renderCount.current === 2) {
+            throw new Error('Intentional Error on re-render');
+        }
+        renderCount.current++;
+        return <div>Rendered</div>;
     },
 });

--- a/packages/react-board/test/fixtures/throwing-on-click.board.tsx
+++ b/packages/react-board/test/fixtures/throwing-on-click.board.tsx
@@ -1,0 +1,14 @@
+import { createBoard } from '@wixc3/react-board';
+import React from 'react';
+
+export default createBoard({
+    name: 'Throwing On Click Board',
+    Board: () => {
+        const ref = React.useRef([1, 2, 3]);
+        return (
+            <div id="divId" onClick={() => ((ref.current as unknown as string) = 'not array')}>
+                {ref.current.map((item) => item)}
+            </div>
+        );
+    },
+});

--- a/packages/react-board/test/fixtures/throwing.board.tsx
+++ b/packages/react-board/test/fixtures/throwing.board.tsx
@@ -1,0 +1,8 @@
+import { createBoard } from '@wixc3/react-board';
+
+export default createBoard({
+    name: 'Throwing Board',
+    Board: () => {
+        throw new Error('Intentional Mount Error');
+    },
+});


### PR DESCRIPTION
In `react@18`, errors weren't rejected correctly in `reactErrorHandledRendering`, leading to an inconsistent flow within the `ErrorBoundary` component. The incorrect flow involved the sequence of `getDerivedStateFromError` -> `componentDidMount` -> `componentDidCatch`.

This resulted in `this.props.onRender` (which resolves the render Promise) being invoked before `this.props.reportError` (which should reject the Promise).

To resolve this issue, I made sure `onRender` is called only when no error is present. This ensures that the error rejection is executed appropriately, providing a more reliable error handling mechanism within `reactErrorHandledRendering`.
