### PR TITLE
feat: add ContentSlot component

### DIFF
--- a/packages/react-board/README.md
+++ b/packages/react-board/README.md
@@ -33,7 +33,10 @@ createBoard({
 });
 ```
 
-You can also create boards with separation between the actual content and the board environment.
+You can also create boards with separation between the actual content and the board environment (context providers, board styling).  
+This will be helpful in board templates, to indicate to Codux where to put the component in the generated board.  
+Or in boards, so that when the board is converted to a code snippet, only the children of the `<ContentSlot>` will be included in the snippet.   
+This is useful when the board is wrapped in a router or a context provider that shouldn't be included in the snippet. 
 
 ```tsx
 // hello.board.tsx

--- a/packages/react-board/README.md
+++ b/packages/react-board/README.md
@@ -33,6 +33,27 @@ createBoard({
 });
 ```
 
+You can also create boards with separation between the actual content and the board environment.
+
+```tsx
+// hello.board.tsx
+
+import { createBoard, ContentSlot } from '@wixc3/react-board';
+import { Hello } from './hello';
+
+createBoard({
+  name: 'hello board',
+  board: () => (
+    <SomeWrappingComponent>
+      <p>description</p>
+      <ContentSlot>
+        <Hello name="World" />,
+      </ContentSlot>
+    <SomeWrappingComponent>
+  )
+});
+```
+
 ## License
 
 MIT

--- a/packages/react-board/src/content-slot.tsx
+++ b/packages/react-board/src/content-slot.tsx
@@ -1,0 +1,3 @@
+export function ContentSlot(props: { children?: React.ReactNode; name?: string }) {
+    return props.children;
+}

--- a/packages/react-board/src/index.ts
+++ b/packages/react-board/src/index.ts
@@ -1,2 +1,3 @@
 export * from './create-board';
 export * from './types';
+export * from './content-slot';


### PR DESCRIPTION
add a `ContentSlot` component which will be used in boards to wrap the actual content(s) of the board.
usually a componnet