### PR TITLE
feat(react-board): Add readyToSnapshot prop to IReactBoard

### DIFF
--- a/packages/react-board/src/types.ts
+++ b/packages/react-board/src/types.ts
@@ -34,6 +34,9 @@ export interface IReactBoard extends IRenderableMetadataBase<IReactBoardHooks<ne
     /** Defines whether the board can be used as a snippet. */
     isSnippet?: boolean;
 
+    /** The delay in milliseconds before taking a snapshot of the board for thumbnail. */
+    thumbnailSnapshotDelay?: number;
+
     /** A React component representing the board. */
     Board: React.ComponentType<any>;
 }

--- a/packages/react-board/src/types.ts
+++ b/packages/react-board/src/types.ts
@@ -34,8 +34,8 @@ export interface IReactBoard extends IRenderableMetadataBase<IReactBoardHooks<ne
     /** Defines whether the board can be used as a snippet. */
     isSnippet?: boolean;
 
-    /** The delay in milliseconds before taking a snapshot of the board for thumbnail. */
-    thumbnailSnapshotDelay?: number;
+    /** A function that indicates that board is ready to be snapshotted */
+    readyToSnapshot?: () => Promise<void>;
 
     /** A React component representing the board. */
     Board: React.ComponentType<any>;


### PR DESCRIPTION
Adding `readyToSnapshot` property, so user can configure the delay for thumbnail snapshot