### PR TITLE
feat!: remove canvas style and editing capabilities

### DIFF
--- a/packages/board-core/src/setup-stage.tsx
+++ b/packages/board-core/src/setup-stage.tsx
@@ -50,5 +50,10 @@ export const setupBoardStage: BoardSetupStageFunction = (board, parentElement) =
         }
     };
 
-    return { canvas, updateWindow, cleanup };
+    // backward compatibility with older version of Codux
+    function updateCanvas() {
+        return;
+    }
+
+    return { canvas, updateWindow, updateCanvas, cleanup };
 };

--- a/packages/board-core/src/setup-stage.tsx
+++ b/packages/board-core/src/setup-stage.tsx
@@ -26,9 +26,11 @@ const applyStylesToWindow = (windowStyles: IWindowEnvironmentProps = {}, previou
 
 export const setupBoardStage: BoardSetupStageFunction = (board, parentElement) => {
     const previousWindowEnvironmentProps: IWindowEnvironmentProps = {};
-    const canvas = parentElement.appendChild(document.createElement('div'));
-
+    const canvas = document.createElement('div');
     callHooks(board, 'beforeAppendCanvas', canvas);
+
+    parentElement.appendChild(canvas);
+
     canvas.setAttribute('id', 'board-canvas');
 
     const { environmentProps } = board;

--- a/packages/board-core/src/setup-stage.tsx
+++ b/packages/board-core/src/setup-stage.tsx
@@ -1,29 +1,14 @@
 import { callHooks } from './hooks';
-import type { BoardSetupStageFunction, IWindowEnvironmentProps, ICanvasEnvironmentProps, CanvasStyles } from './types';
+import type { BoardSetupStageFunction, IWindowEnvironmentProps } from './types';
 
 export const defaultWindowStyles = {
     width: 1024,
     height: 640,
 } as const;
 
-export const defaultCanvasStyles: CanvasStyles = {
-    width: 'fit-content',
-    height: 'fit-content',
-    marginLeft: 'auto',
-    marginRight: 'auto',
-    marginBottom: 'auto',
-    marginTop: 'auto',
-    paddingLeft: '0px',
-    paddingRight: '0px',
-    paddingBottom: '0px',
-    paddingTop: '0px',
-} as const;
-
 export const defaultEnvironmentProperties = {
     windowWidth: defaultWindowStyles.width,
     windowHeight: defaultWindowStyles.height,
-    canvasMargin: {},
-    canvasPadding: {},
 };
 
 const applyStylesToWindow = (windowStyles: IWindowEnvironmentProps = {}, previousProps: IWindowEnvironmentProps) => {
@@ -39,64 +24,6 @@ const applyStylesToWindow = (windowStyles: IWindowEnvironmentProps = {}, previou
     document.body.style.backgroundColor = windowStyles.windowBackgroundColor || '';
 };
 
-const applyStylesToCanvas = (canvas: HTMLDivElement, environmentProps: ICanvasEnvironmentProps = {}) => {
-    const canvasStyle = {
-        width:
-            environmentProps.canvasWidth !== undefined
-                ? `${environmentProps.canvasWidth}px`
-                : defaultCanvasStyles.width,
-        height:
-            environmentProps.canvasHeight !== undefined
-                ? `${environmentProps.canvasHeight}px`
-                : defaultCanvasStyles.height,
-        marginLeft:
-            environmentProps.canvasMargin?.left !== undefined
-                ? `${environmentProps.canvasMargin?.left}px`
-                : defaultCanvasStyles.marginLeft,
-        marginRight:
-            environmentProps.canvasMargin?.right !== undefined
-                ? `${environmentProps.canvasMargin?.right}px`
-                : defaultCanvasStyles.marginRight,
-        marginBottom:
-            environmentProps.canvasMargin?.bottom !== undefined
-                ? `${environmentProps.canvasMargin?.bottom}px`
-                : defaultCanvasStyles.marginBottom,
-        marginTop:
-            environmentProps.canvasMargin?.top !== undefined
-                ? `${environmentProps.canvasMargin?.top}px`
-                : defaultCanvasStyles.marginTop,
-        paddingLeft:
-            environmentProps.canvasPadding?.left !== undefined
-                ? `${environmentProps.canvasPadding?.left}px`
-                : defaultCanvasStyles.paddingLeft,
-        paddingRight:
-            environmentProps.canvasPadding?.right !== undefined
-                ? `${environmentProps.canvasPadding?.right}px`
-                : defaultCanvasStyles.paddingRight,
-        paddingBottom:
-            environmentProps.canvasPadding?.bottom !== undefined
-                ? `${environmentProps.canvasPadding?.bottom}px`
-                : defaultCanvasStyles.paddingBottom,
-        paddingTop:
-            environmentProps.canvasPadding?.top !== undefined
-                ? `${environmentProps.canvasPadding?.top}px`
-                : defaultCanvasStyles.paddingTop,
-        backgroundColor: environmentProps.canvasBackgroundColor || '',
-    };
-
-    // Canvas gets stretched horizontally/vertically
-    // when horizontal (left and right) or vertical (top and bottom) margins are applied.
-    if (environmentProps.canvasMargin?.left !== undefined && environmentProps.canvasMargin.right !== undefined) {
-        canvasStyle.width = '100%';
-    }
-
-    if (environmentProps.canvasMargin?.top !== undefined && environmentProps.canvasMargin.bottom !== undefined) {
-        canvasStyle.height = 'auto';
-    }
-
-    Object.assign(canvas.style, canvasStyle);
-};
-
 export const setupBoardStage: BoardSetupStageFunction = (board, parentElement) => {
     const previousWindowEnvironmentProps: IWindowEnvironmentProps = {};
     const canvas = parentElement.appendChild(document.createElement('div'));
@@ -110,19 +37,7 @@ export const setupBoardStage: BoardSetupStageFunction = (board, parentElement) =
         applyStylesToWindow(windowEnvironmentProps, previousWindowEnvironmentProps);
     };
 
-    const updateCanvas = (canvasEnvironmentProps: ICanvasEnvironmentProps) => {
-        if (canvasEnvironmentProps.showCanvas) {
-            applyStylesToCanvas(canvas, canvasEnvironmentProps);
-        } else {
-            Object.assign(canvas.style, {});
-        }
-    };
-
     applyStylesToWindow(environmentProps, previousWindowEnvironmentProps);
-
-    if (environmentProps?.showCanvas) {
-        applyStylesToCanvas(canvas, environmentProps);
-    }
 
     const cleanup = () => {
         callHooks(board, 'beforeStageCleanUp', canvas);
@@ -133,5 +48,5 @@ export const setupBoardStage: BoardSetupStageFunction = (board, parentElement) =
         }
     };
 
-    return { canvas, updateCanvas, updateWindow, cleanup };
+    return { canvas, updateWindow, cleanup };
 };

--- a/packages/board-core/src/setup-stage.tsx
+++ b/packages/board-core/src/setup-stage.tsx
@@ -50,7 +50,8 @@ export const setupBoardStage: BoardSetupStageFunction = (board, parentElement) =
         }
     };
 
-    // backward compatibility with older version of Codux
+    // backward compatibility with older versions
+    //  of Codux that still use updateCanvas
     function updateCanvas() {
         return;
     }

--- a/packages/board-core/src/setup-stage.tsx
+++ b/packages/board-core/src/setup-stage.tsx
@@ -99,25 +99,30 @@ const applyStylesToCanvas = (canvas: HTMLDivElement, environmentProps: ICanvasEn
 
 export const setupBoardStage: BoardSetupStageFunction = (board, parentElement) => {
     const previousWindowEnvironmentProps: IWindowEnvironmentProps = {};
-    const canvas = document.createElement('div');
+    const canvas = parentElement.appendChild(document.createElement('div'));
+
+    callHooks(board, 'beforeAppendCanvas', canvas);
     canvas.setAttribute('id', 'board-canvas');
 
     const { environmentProps } = board;
 
-    applyStylesToWindow(environmentProps, previousWindowEnvironmentProps);
-    applyStylesToCanvas(canvas, environmentProps);
-
-    callHooks(board, 'beforeAppendCanvas', canvas);
-
-    parentElement.appendChild(canvas);
-
-    const updateCanvas = (canvasEnvironmentProps: ICanvasEnvironmentProps) => {
-        applyStylesToCanvas(canvas, canvasEnvironmentProps);
-    };
-
     const updateWindow = (windowEnvironmentProps: IWindowEnvironmentProps) => {
         applyStylesToWindow(windowEnvironmentProps, previousWindowEnvironmentProps);
     };
+
+    const updateCanvas = (canvasEnvironmentProps: ICanvasEnvironmentProps) => {
+        if (canvasEnvironmentProps.showCanvas) {
+            applyStylesToCanvas(canvas, canvasEnvironmentProps);
+        } else {
+            Object.assign(canvas.style, {});
+        }
+    };
+
+    applyStylesToWindow(environmentProps, previousWindowEnvironmentProps);
+
+    if (environmentProps?.showCanvas) {
+        applyStylesToCanvas(canvas, environmentProps);
+    }
 
     const cleanup = () => {
         callHooks(board, 'beforeStageCleanUp', canvas);

--- a/packages/board-core/src/types.ts
+++ b/packages/board-core/src/types.ts
@@ -25,17 +25,15 @@ export interface IWindowEnvironmentProps {
 }
 
 export interface ICanvasEnvironmentProps {
-    /** @visualizer toggleCanvas */
-    showCanvas?: boolean;
-    /** @visualizer spacing */
+    /** @deprecated canvas cannot be edited anymore, create your own container to control the preview */
     canvasWidth?: LayoutSizeWithAuto | undefined;
-    /** @visualizer spacing */
+    /** @deprecated canvas cannot be edited anymore, create your own container to control the preview */
     canvasHeight?: LayoutSizeWithAuto | undefined;
-    /** @visualizer color */
+    /** @deprecated canvas cannot be edited anymore, create your own container to control the preview */
     canvasBackgroundColor?: string | undefined;
-    /** @visualizer canvasMargin */
+    /** @deprecated canvas cannot be edited anymore, create your own container to control the preview */
     canvasMargin?: LayoutSpacing | undefined;
-    /** @visualizer canvasPadding */
+    /** @deprecated canvas cannot be edited anymore, create your own container to control the preview */
     canvasPadding?: LayoutSpacing | undefined;
 }
 
@@ -157,20 +155,5 @@ export type BoardSetupStageFunction = (
 ) => {
     canvas: HTMLElement;
     cleanup: () => void;
-    updateCanvas: (canvasEnvironmentProps: ICanvasEnvironmentProps) => void;
     updateWindow: (windowEnvironmentProps: IWindowEnvironmentProps) => void;
 };
-
-export type CanvasStyles = Pick<
-    CSSStyleDeclaration,
-    | 'height'
-    | 'width'
-    | 'paddingLeft'
-    | 'paddingRight'
-    | 'paddingBottom'
-    | 'paddingTop'
-    | 'marginLeft'
-    | 'marginRight'
-    | 'marginBottom'
-    | 'marginTop'
->;

--- a/packages/board-core/src/types.ts
+++ b/packages/board-core/src/types.ts
@@ -25,6 +25,8 @@ export interface IWindowEnvironmentProps {
 }
 
 export interface ICanvasEnvironmentProps {
+    /** @visualizer toggleCanvas */
+    showCanvas?: boolean;
     /** @visualizer spacing */
     canvasWidth?: LayoutSizeWithAuto | undefined;
     /** @visualizer spacing */

--- a/packages/board-core/src/types.ts
+++ b/packages/board-core/src/types.ts
@@ -155,5 +155,6 @@ export type BoardSetupStageFunction = (
 ) => {
     canvas: HTMLElement;
     cleanup: () => void;
+    updateCanvas: (canvasEnvironmentProps: ICanvasEnvironmentProps) => void;
     updateWindow: (windowEnvironmentProps: IWindowEnvironmentProps) => void;
 };

--- a/packages/react-board/test/setup-stage.spec.tsx
+++ b/packages/react-board/test/setup-stage.spec.tsx
@@ -16,7 +16,7 @@ describe('setupBoardStage', () => {
         document.body.appendChild(container);
         disposables.add(() => document.body.removeChild(container));
 
-        const { canvas, cleanup, updateCanvas, updateWindow } = setupBoardStage(
+        const { canvas, cleanup, updateWindow } = setupBoardStage(
             createBoard({
                 name: 'Test1',
                 Board: () => null,
@@ -26,58 +26,13 @@ describe('setupBoardStage', () => {
 
         disposables.add(cleanup);
 
-        return { canvas, container, updateWindow, updateCanvas };
+        return { canvas, container, updateWindow };
     }
 
     it('renders the canvas into a parent element', () => {
         const { canvas, container } = setupBoard();
 
         expect(canvas.parentElement, 'canvas was not rendered into a provided container').to.eql(container);
-    });
-
-    it('sets canvas height and canvas width to the provided values if no margin is provided', () => {
-        const { updateCanvas, canvas } = setupBoard();
-
-        const canvasWidth = 420;
-        const canvasHeight = 690;
-
-        updateCanvas({
-            canvasWidth,
-            canvasHeight,
-        });
-
-        expect(canvas.offsetWidth, 'canvas width was not updated').equal(canvasWidth);
-        expect(canvas.offsetHeight, 'canvas height was not updated').equal(canvasHeight);
-    });
-
-    it('sets canvas height to auto if a "top" and "bottom" margin is provided', () => {
-        const { updateCanvas, canvas } = setupBoard();
-
-        updateCanvas({ canvasHeight: 5, canvasMargin: { top: 5, bottom: 5 } });
-
-        expect(canvas?.offsetHeight, 'canvas height is not stretched when margins are applied').equal(
-            CONTAINER_HEIGHT - 2 * 5,
-        );
-    });
-
-    it('sets canvas width to auto if "left" and "right" margin is provided', () => {
-        const { updateCanvas, canvas } = setupBoard();
-
-        updateCanvas({ canvasWidth: 5, canvasMargin: { left: 5, right: 5 } });
-
-        expect(canvas?.offsetWidth, 'canvas width is not stretched when margins are applied').equal(
-            window.innerWidth - 2 * 5,
-        );
-    });
-
-    it('sets canvas background color', () => {
-        const { updateCanvas, canvas } = setupBoard();
-
-        updateCanvas({ canvasBackgroundColor: '#fff' });
-
-        expect(window.getComputedStyle(canvas).backgroundColor, 'canvas background color was not updated').equal(
-            'rgb(255, 255, 255)',
-        );
     });
 
     it('sets window dimensions', () => {


### PR DESCRIPTION
The Canvas functionality is being deprecated. 

This PR removes the following functionalities in Codux:
1. Canvas cannot be edited from the stage or the Board Settings panel.
2. Canvas will not be centered on stage.
3. Pre-defined canvas related environment props will not take effect.

Changes include:
- Deprecation of the canvas environment properties.
- Removal of the functionality of editing the canvas.  
- Removal of the styles from body and the canvas.
