### PR TITLE
feat(content-slot): wrap children in a div with data attribute

### DIFF
--- a/packages/react-board/src/content-slot.tsx
+++ b/packages/react-board/src/content-slot.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export function ContentSlot(props: { children?: React.ReactNode; name?: string }) {
-    return props.children;
+    return <div data-content-slot={props.name}>{props.children}</div>;
 }

--- a/packages/react-board/src/content-slot.tsx
+++ b/packages/react-board/src/content-slot.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-export function ContentSlot(props: { children?: React.ReactNode; className?: string; name?: string }) {
+export function ContentSlot(props: { children?: React.ReactNode; name?: string }) {
     return (
-        <div className={props.className} data-content-slot={props.name}>
+        <div data-content-slot={props.name} style={{ display: 'contents' }}>
             {props.children}
         </div>
     );

--- a/packages/react-board/src/content-slot.tsx
+++ b/packages/react-board/src/content-slot.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 
-export function ContentSlot(props: { children?: React.ReactNode; name?: string }) {
-    return <div data-content-slot={props.name}>{props.children}</div>;
+export function ContentSlot(props: { children?: React.ReactNode; className?: string; name?: string }) {
+    return (
+        <div className={props.className} data-content-slot={props.name}>
+            {props.children}
+        </div>
+    );
 }


### PR DESCRIPTION
Following a talk with @alisey, this change should provide a way to differentiate one content slot from another when processed in Codux. 🥷🏼