### PR TITLE
feat(react-board): add `Variant` component

### DIFF
--- a/packages/react-board/src/variant.tsx
+++ b/packages/react-board/src/variant.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export function Variant(props: { children?: React.ReactNode; name?: string }) {
+    return (
+        <div data-variant={props.name || ''} style={{ display: 'contents' }}>
+            {props.children}
+        </div>
+    );
+}


### PR DESCRIPTION
Currently, it is the same as `ContentSlot`, just a different name and data attribute.