### PR TITLE
fix(define-remix-app): validate and normalize new page

### DIFF
--- a/packages/app-core/src/define-app-types.ts
+++ b/packages/app-core/src/define-app-types.ts
@@ -112,7 +112,7 @@ export interface IReactApp<T = unknown> {
         warningMessage?: string;
         pageModule: string;
         newPageSourceCode: string;
-        newPageRoute: RouteInfo<T>;
+        newPageRoute?: RouteInfo<T>;
     };
 
     /**
@@ -125,7 +125,7 @@ export interface IReactApp<T = unknown> {
         errorMessage?: string;
         warningMessage?: string;
         pageModule: string;
-        newPageRoute: RouteInfo<T>;
+        newPageRoute?: RouteInfo<T>;
     };
     App: React.ComponentType<IReactAppProps<T>>;
     /**

--- a/packages/define-remix-app/src/define-remix-app.tsx
+++ b/packages/define-remix-app/src/define-remix-app.tsx
@@ -41,6 +41,7 @@ export const INVALID_MSGS = {
     initialPageLetter: 'page name must start with an a letter between a-z',
     invalidVar: (varName: string) =>
         `invalid variable name: "${varName}", page params must start with a letter or underscore and contain only letters, numbers and underscores`,
+    invalidRouteChar: (param: string, char: string) => `invalid character "${char}" in page route ${param}`,
 };
 
 export default function defineRemixApp({ appPath, routingPattern }: IDefineRemixAppProps) {
@@ -129,6 +130,20 @@ export default function defineRemixApp({ appPath, routingPattern }: IDefineRemix
                 pageModule: '',
                 newPageSourceCode: '',
             };
+        }
+
+        for (const part of wantedPath) {
+            if (part.kind === 'static') {
+                const matchedInvalidChars = part.text.match(/[/\\:*?"'`<>|]/g);
+                if (matchedInvalidChars) {
+                    return {
+                        isValid: false,
+                        errorMessage: INVALID_MSGS.invalidRouteChar(part.text, matchedInvalidChars.join('')),
+                        pageModule: '',
+                        newPageSourceCode: '',
+                    };
+                }
+            }
         }
 
         const newPageSourceCode = pageTemplate(pageName, varNames);

--- a/packages/define-remix-app/src/define-remix-app.tsx
+++ b/packages/define-remix-app/src/define-remix-app.tsx
@@ -39,6 +39,8 @@ export const INVALID_MSGS = {
     homeRouteExists: (routePath: string) => 'Home route already exists at ' + routePath,
     emptyName: 'page name cannot be empty',
     initialPageLetter: 'page name must start with an a letter between a-z',
+    invalidVar: (varName: string) =>
+        `invalid variable name: "${varName}", page params must start with a letter or underscore and contain only letters, numbers and underscores`,
 };
 
 export default function defineRemixApp({ appPath, routingPattern }: IDefineRemixAppProps) {
@@ -115,6 +117,18 @@ export default function defineRemixApp({ appPath, routingPattern }: IDefineRemix
                     newPageRoute: existingRoute,
                 };
             }
+        }
+
+        const invalidVar = [...varNames].find(
+            (varName) => !varName || !varName[0].match(/[A-Za-z_]/) || !varName.match(/^[A-Za-z_0-9]+$/),
+        );
+        if (invalidVar) {
+            return {
+                isValid: false,
+                errorMessage: INVALID_MSGS.invalidVar(invalidVar),
+                pageModule: '',
+                newPageSourceCode: '',
+            };
         }
 
         const newPageSourceCode = pageTemplate(pageName, varNames);

--- a/packages/define-remix-app/src/define-remix-app.tsx
+++ b/packages/define-remix-app/src/define-remix-app.tsx
@@ -35,6 +35,12 @@ export interface IDefineRemixAppProps {
     routingPattern?: RoutingPattern;
 }
 
+export const INVALID_MSGS = {
+    homeRouteExists: (routePath: string) => 'Home route already exists at ' + routePath,
+    emptyName: 'page name cannot be empty',
+    initialPageLetter: 'page name must start with an a letter between a-z',
+};
+
 export default function defineRemixApp({ appPath, routingPattern }: IDefineRemixAppProps) {
     let rootLayouts: RouteExtraInfo['parentLayouts'] = [];
     let layoutMap: Map<string, ParentLayoutWithExtra> = new Map();
@@ -65,10 +71,9 @@ export default function defineRemixApp({ appPath, routingPattern }: IDefineRemix
         if (requestedURI.length === 0 && manifest.homeRoute) {
             return {
                 isValid: false,
-                errorMessage: 'Home route already exists at ' + manifest.homeRoute.pageModule,
-                pageModule: manifest.homeRoute.pageModule,
+                errorMessage: INVALID_MSGS.homeRouteExists(manifest.homeRoute.pageModule),
+                pageModule: '',
                 newPageSourceCode: '',
-                newPageRoute: manifest.homeRoute,
             };
         }
         const wantedPathId = routePathId(wantedPath);
@@ -84,6 +89,21 @@ export default function defineRemixApp({ appPath, routingPattern }: IDefineRemix
             })
             .join('.');
         const pageName = toCamelCase(pageFileName);
+        if (!pageName) {
+            return {
+                isValid: false,
+                errorMessage: INVALID_MSGS.emptyName,
+                pageModule: '',
+                newPageSourceCode: '',
+            };
+        } else if (!pageName[0].match(/[A-Za-z]/)) {
+            return {
+                isValid: false,
+                errorMessage: 'page name must start with an a letter between a-z',
+                pageModule: '',
+                newPageSourceCode: '',
+            };
+        }
 
         if (existingRoute) {
             if (!canFilePathBeLayout(existingRoute.pageModule, fsApi) || canFilePathBeLayout(pageModule, fsApi)) {

--- a/packages/define-remix-app/src/index.ts
+++ b/packages/define-remix-app/src/index.ts
@@ -2,3 +2,4 @@ export * from './define-remix-app';
 import defineRemixApp from './define-remix-app';
 export default defineRemixApp;
 export * from './content';
+export { pageTemplate } from './page-template';

--- a/packages/define-remix-app/src/page-template.ts
+++ b/packages/define-remix-app/src/page-template.ts
@@ -1,9 +1,10 @@
 export const pageTemplate = (pageName: string, varNames: Set<string>) => {
+    const compIdentifier = pageName[0].toUpperCase() + pageName.slice(1);
     return varNames.size === 0
         ? `
 import React from 'react';
-export default function ${pageName}() {
-return <div>${pageName}</div>;
+export default function ${compIdentifier}() {
+return <div>${cleanJSxText(pageName)}</div>;
 }
 `
         : `
@@ -16,14 +17,18 @@ ${[...varNames].map((name) => `${name}: string`).join(',\n')}
 return params;
 };
 
-const ${pageName} = () => {
+const ${compIdentifier} = () => {
 const params = useLoaderData<typeof loader>();
 return <div>
-${[...varNames].map((name) => `<div>${name}: {params.${name}}</div>`).join('\n')}
+${[...varNames].map((name) => `<div>${cleanJSxText(name)}: {params["${name}}"]</div>`).join('\n')}
 </div>;
 };
-export default ${pageName};
+export default ${compIdentifier};
   
         
         `;
 };
+
+function cleanJSxText(txt: string) {
+    return txt.replace(/[{}<>]/g, '');
+}

--- a/packages/define-remix-app/src/page-template.ts
+++ b/packages/define-remix-app/src/page-template.ts
@@ -4,7 +4,7 @@ export const pageTemplate = (pageName: string, varNames: Set<string>) => {
         ? `
 import React from 'react';
 export default function ${compIdentifier}() {
-return <div>${cleanJSxText(pageName)}</div>;
+return <div>${clearJsxSpecialCharactersFromText(pageName)}</div>;
 }
 `
         : `
@@ -20,7 +20,7 @@ return params;
 const ${compIdentifier} = () => {
 const params = useLoaderData<typeof loader>();
 return <div>
-${[...varNames].map((name) => `<div>${cleanJSxText(name)}: {params["${name}}"]</div>`).join('\n')}
+${[...varNames].map((name) => `<div>${clearJsxSpecialCharactersFromText(name)}: {params["${name}}"]</div>`).join('\n')}
 </div>;
 };
 export default ${compIdentifier};
@@ -29,7 +29,7 @@ export default ${compIdentifier};
         `;
 };
 
-function cleanJSxText(txt: string) {
+function clearJsxSpecialCharactersFromText(txt: string) {
     return txt.replace(/[{}<>]/g, '');
 }
 function cleanInvalidJsIdentChars(txt: string) {

--- a/packages/define-remix-app/src/page-template.ts
+++ b/packages/define-remix-app/src/page-template.ts
@@ -1,5 +1,5 @@
 export const pageTemplate = (pageName: string, varNames: Set<string>) => {
-    const compIdentifier = pageName[0].toUpperCase() + pageName.slice(1);
+    const compIdentifier = cleanInvalidJsIdentChars(pageName[0].toUpperCase() + pageName.slice(1));
     return varNames.size === 0
         ? `
 import React from 'react';
@@ -31,4 +31,7 @@ export default ${compIdentifier};
 
 function cleanJSxText(txt: string) {
     return txt.replace(/[{}<>]/g, '');
+}
+function cleanInvalidJsIdentChars(txt: string) {
+    return txt.replace(/[!@#%^&*()\-+=[\]{}|;:'",.<>?/~\\`\s]/g, '');
 }

--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -705,7 +705,7 @@ describe('define-remix', () => {
                 expect(newPageSourceCode, 'newPageSourceCode').to.eql('');
                 expect(newPageRoute, 'newPageRoute').to.eql(undefined);
             });
-            it('should not allow page the start without an english first letter', async () => {
+            it('should not allow the page to start without an english first letter', async () => {
                 const { driver } = await getInitialManifest({
                     [indexPath]: simpleLayout,
                 });

--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -686,6 +686,20 @@ describe('define-remix', () => {
                 expect(newPageSourceCode, 'newPageSourceCode').to.eql('');
                 expect(newPageRoute, 'newPageRoute').to.eql(undefined);
             });
+            it('should limit route param key', async () => {
+                const { driver } = await getInitialManifest({
+                    [indexPath]: simpleLayout,
+                });
+
+                const { isValid, errorMessage, pageModule, newPageRoute, newPageSourceCode } =
+                    driver.getNewPageInfo('about/$a+b');
+
+                expect(isValid, 'isValid').to.eql(false);
+                expect(errorMessage, 'error message').to.eql(INVALID_MSGS.invalidVar('a+b'));
+                expect(pageModule, 'page module').to.eql('');
+                expect(newPageSourceCode, 'newPageSourceCode').to.eql('');
+                expect(newPageRoute, 'newPageRoute').to.eql(undefined);
+            });
         });
     });
     describe('getMovePageInfo', () => {

--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -1,4 +1,4 @@
-import defineRemixApp, { INVALID_MSGS, parentLayoutWarning } from '@wixc3/define-remix-app';
+import defineRemixApp, { INVALID_MSGS, parentLayoutWarning, pageTemplate } from '@wixc3/define-remix-app';
 import { AppDefDriver } from '@wixc3/app-core/test-kit';
 import {
     loaderOnly,
@@ -641,6 +641,31 @@ describe('define-remix', () => {
                 }),
             );
             expect(warningMessage).to.include(parentLayoutWarning('about', 'about_/_index'));
+        });
+        describe('normalize generate page injected code', () => {
+            it('should normalize the component identifier', async () => {
+                const { driver } = await getInitialManifest({
+                    [indexPath]: simpleLayout,
+                });
+                const { newPageSourceCode } = driver.getNewPageInfo('about');
+
+                expect(newPageSourceCode, 'Capital letter').to.include('export default function About() {');
+            });
+            it('should cleanup initial JSX content', async () => {
+                const { driver } = await getInitialManifest({
+                    [indexPath]: simpleLayout,
+                });
+                const { newPageSourceCode } = driver.getNewPageInfo('about{}');
+
+                expect(newPageSourceCode, 'curly braces').to.include('return <div>about</div>;');
+
+                // This test also directly targets the template function since
+                // angle braces would fail route validation and never reach the
+                // template function in normal execution.
+                const pageSource = pageTemplate('ab<>{}out', new Set());
+
+                expect(pageSource).to.include('return <div>about</div>;');
+            });
         });
         describe('invalid input', () => {
             it('should not allow new page to override home route', async () => {

--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -1,4 +1,4 @@
-import defineRemixApp, { parentLayoutWarning } from '@wixc3/define-remix-app';
+import defineRemixApp, { INVALID_MSGS, parentLayoutWarning } from '@wixc3/define-remix-app';
 import { AppDefDriver } from '@wixc3/app-core/test-kit';
 import {
     loaderOnly,
@@ -641,6 +641,51 @@ describe('define-remix', () => {
                 }),
             );
             expect(warningMessage).to.include(parentLayoutWarning('about', 'about_/_index'));
+        });
+        describe('invalid input', () => {
+            it('should not allow new page to override home route', async () => {
+                const { driver } = await getInitialManifest({
+                    [indexPath]: simpleLayout,
+                });
+
+                const { isValid, errorMessage, pageModule, newPageRoute, newPageSourceCode } =
+                    driver.getNewPageInfo('');
+
+                expect(isValid, 'isValid').to.eql(false);
+                expect(errorMessage, 'error message').to.eql(INVALID_MSGS.homeRouteExists('/app/routes/_index.tsx'));
+                expect(pageModule, 'page module').to.eql('');
+                expect(newPageSourceCode, 'newPageSourceCode').to.eql('');
+                expect(newPageRoute, 'newPageRoute').to.eql(undefined);
+            });
+            it('should not allow empty page name (with no home route)', async () => {
+                const { driver, manifest } = await getInitialManifest({
+                    [indexPath]: simpleLayout,
+                });
+                delete manifest.homeRoute;
+
+                const { isValid, errorMessage, pageModule, newPageRoute, newPageSourceCode } =
+                    driver.getNewPageInfo('');
+
+                expect(isValid, 'isValid').to.eql(false);
+                expect(errorMessage, 'error message').to.eql(INVALID_MSGS.emptyName);
+                expect(pageModule, 'page module').to.eql('');
+                expect(newPageSourceCode, 'newPageSourceCode').to.eql('');
+                expect(newPageRoute, 'newPageRoute').to.eql(undefined);
+            });
+            it('should not allow page the start without an english first letter', async () => {
+                const { driver } = await getInitialManifest({
+                    [indexPath]: simpleLayout,
+                });
+
+                const { isValid, errorMessage, pageModule, newPageRoute, newPageSourceCode } =
+                    driver.getNewPageInfo('1st-page');
+
+                expect(isValid, 'isValid').to.eql(false);
+                expect(errorMessage, 'error message').to.eql(INVALID_MSGS.initialPageLetter);
+                expect(pageModule, 'page module').to.eql('');
+                expect(newPageSourceCode, 'newPageSourceCode').to.eql('');
+                expect(newPageRoute, 'newPageRoute').to.eql(undefined);
+            });
         });
     });
     describe('getMovePageInfo', () => {

--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -700,6 +700,24 @@ describe('define-remix', () => {
                 expect(newPageSourceCode, 'newPageSourceCode').to.eql('');
                 expect(newPageRoute, 'newPageRoute').to.eql(undefined);
             });
+            it('should not allow route value that is not valid in fs', async () => {
+                const { driver } = await getInitialManifest({
+                    [indexPath]: simpleLayout,
+                });
+                const invalidFsChars = ['\\', ':', '*', '?', '"', "'", '`', '<', '>', '|'];
+                for (const invalidChar of invalidFsChars) {
+                    const { isValid, errorMessage, pageModule, newPageRoute, newPageSourceCode } =
+                        driver.getNewPageInfo('about/$param/invalid-' + invalidChar);
+
+                    expect(isValid, `isValid ${invalidChar}`).to.eql(false);
+                    expect(errorMessage, `error message ${invalidChar}`).to.eql(
+                        INVALID_MSGS.invalidRouteChar('invalid-' + invalidChar, invalidChar),
+                    );
+                    expect(pageModule, `page module ${invalidChar}`).to.eql('');
+                    expect(newPageSourceCode, `newPageSourceCode ${invalidChar}`).to.eql('');
+                    expect(newPageRoute, `newPageRoute ${invalidChar}`).to.eql(undefined);
+                }
+            });
         });
     });
     describe('getMovePageInfo', () => {

--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -651,6 +651,14 @@ describe('define-remix', () => {
 
                 expect(newPageSourceCode, 'Capital letter').to.include('export default function About() {');
             });
+            it('should remove invalid ident chars from the component identifier', async () => {
+                const { driver } = await getInitialManifest({
+                    [indexPath]: simpleLayout,
+                });
+                const { newPageSourceCode } = driver.getNewPageInfo('Abou#t');
+
+                expect(newPageSourceCode, 'Capital letter').to.include('export default function About() {');
+            });
             it('should cleanup initial JSX content', async () => {
                 const { driver } = await getInitialManifest({
                     [indexPath]: simpleLayout,


### PR DESCRIPTION
This PR enhances the "Generate New Page" flow by introducing both validation and normalization steps.

**Validations:**
 - Ensure the component name starts with an english letter, as it must be capitalized and valid as the first character of a JavaScript identifier.
 - Validate that the route is not empty.
 - Restrict route parameters to contain only english letters and underscores for the first character, and allow numbers for subsequent characters.
 - Validate that the route contains only characters that are safe to use in file and folder names on the file system.
 - Added a test to confirm the existing validation that prevents overriding the home route.

**Normalization:**
- Remove `<>{}` from the initial JSX content.
- Strip any non-identifier characters from the component name.

