### PR TITLE
fix(define-remix-app): supports navigation to URIs starting with '/'

### DIFF
--- a/packages/define-remix-app/src/define-remix-app.tsx
+++ b/packages/define-remix-app/src/define-remix-app.tsx
@@ -147,7 +147,7 @@ export default function defineRemixApp({ appPath, routingPattern }: IDefineRemix
             );
 
             useEffect(() => {
-                navigate(uri.startsWith('/') ? uri : '/' + uri);
+                navigate(uri.startsWith('/') ? uri : `/${uri}`);
             }, [uri, navigate]);
 
             return (

--- a/packages/define-remix-app/src/define-remix-app.tsx
+++ b/packages/define-remix-app/src/define-remix-app.tsx
@@ -147,7 +147,7 @@ export default function defineRemixApp({ appPath, routingPattern }: IDefineRemix
             );
 
             useEffect(() => {
-                navigate('/' + uri);
+                navigate(uri.startsWith('/') ? uri : '/' + uri);
             }, [uri, navigate]);
 
             return (


### PR DESCRIPTION
Handling cases where the passed URI starts with a forward slash.

NOTE
Tests should be added in a different PR using a suite for running define-remix-app in the browser.