### PR TITLE
feat(app-core): provide routing pattern in new / moved page results

### DIFF
--- a/packages/app-core/src/define-app-types.ts
+++ b/packages/app-core/src/define-app-types.ts
@@ -113,6 +113,7 @@ export interface IReactApp<T = unknown> {
         pageModule: string;
         newPageSourceCode: string;
         newPageRoute?: RouteInfo<T>;
+        routingPattern?: RoutingPattern;
     };
 
     /**
@@ -126,6 +127,7 @@ export interface IReactApp<T = unknown> {
         warningMessage?: string;
         pageModule: string;
         newPageRoute?: RouteInfo<T>;
+        routingPattern?: RoutingPattern;
     };
     App: React.ComponentType<IReactAppProps<T>>;
     /**
@@ -212,6 +214,9 @@ export interface IGetNewPageInfoOptions<T> {
     requestedURI: string;
     manifest: IAppManifest<T>;
 }
+
+export type RoutingPattern = 'file' | 'folder(route)' | 'folder(index)';
+
 export interface IMovePageInfoOptions<T> extends IGetNewPageInfoOptions<T> {
     movedFilePath: string;
 }

--- a/packages/define-remix-app/src/define-remix-app.tsx
+++ b/packages/define-remix-app/src/define-remix-app.tsx
@@ -6,6 +6,7 @@ import {
     StaticRoutePart,
     FSApi,
     IGetNewPageInfoOptions,
+    RoutingPattern,
 } from '@wixc3/app-core';
 import { useMemo, useRef, useEffect } from 'react';
 import {
@@ -22,7 +23,6 @@ import {
     RouteExtraInfo,
     routePartsToRoutePath,
     routePathId,
-    RoutingPattern,
     toCamelCase,
 } from './remix-app-utils';
 import { manifestToRouter } from './manifest-to-router';
@@ -173,6 +173,7 @@ export default function defineRemixApp({ appPath, routingPattern }: IDefineRemix
             warningMessage,
             newPageSourceCode,
             pageModule,
+            routingPattern,
             newPageRoute: {
                 pageModule,
                 pageExportName: 'default',

--- a/packages/define-remix-app/src/remix-app-utils.ts
+++ b/packages/define-remix-app/src/remix-app-utils.ts
@@ -1,4 +1,4 @@
-import { DynamicRoutePart, PathApi, RouteInfo, StaticRoutePart } from '@wixc3/app-core';
+import { DynamicRoutePart, PathApi, RouteInfo, RoutingPattern, StaticRoutePart } from '@wixc3/app-core';
 
 export interface ParentLayoutWithExtra {
     layoutModule: string;
@@ -12,7 +12,7 @@ export interface RouteExtraInfo {
     routeId: string;
 }
 
-export type RoutingPattern = 'file' | 'folder(route)' | 'folder(index)';
+
 
 export const routePartsToRoutePath = (routeParts: string[]) => {
     return routeParts

--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -9,8 +9,8 @@ import {
     layoutWithErrorBoundary,
 } from './test-cases/roots';
 import { expect } from 'chai';
-import { IAppManifest, RouteInfo } from '@wixc3/app-core';
-import { RouteExtraInfo, RoutingPattern } from '../src/remix-app-utils';
+import { IAppManifest, RouteInfo, RoutingPattern } from '@wixc3/app-core';
+import { RouteExtraInfo } from '../src/remix-app-utils';
 import { waitFor } from 'promise-assist';
 
 const indexPath = '/app/routes/_index.tsx';
@@ -535,7 +535,8 @@ describe('define-remix', () => {
             const { driver } = await getInitialManifest({
                 [indexPath]: simpleLayout,
             });
-            const { isValid, pageModule, newPageRoute, newPageSourceCode } = driver.getNewPageInfo('about');
+            const { isValid, pageModule, newPageRoute, newPageSourceCode, routingPattern } =
+                driver.getNewPageInfo('about');
             expect(isValid).to.eql(true);
             expect(pageModule).to.eql('/app/routes/about.tsx');
             expect(newPageRoute).to.eql(
@@ -547,6 +548,7 @@ describe('define-remix', () => {
                 }),
             );
             expect(newPageSourceCode).to.include('export default');
+            expect(routingPattern).to.eql('file');
         });
         it('should return the correct path for a simple route (dir+route pattern)', async () => {
             const { driver } = await getInitialManifest(
@@ -555,7 +557,7 @@ describe('define-remix', () => {
                 },
                 'folder(route)',
             );
-            const { isValid, pageModule, newPageRoute } = driver.getNewPageInfo('about');
+            const { isValid, pageModule, newPageRoute, routingPattern } = driver.getNewPageInfo('about');
             expect(isValid).to.eql(true);
             expect(pageModule).to.eql('/app/routes/about/route.tsx');
             expect(newPageRoute).to.eql(
@@ -566,6 +568,7 @@ describe('define-remix', () => {
                     path: [urlSeg('about')],
                 }),
             );
+            expect(routingPattern).to.eql('folder(route)');
         });
         it('should return the correct path for a simple route (dir+index pattern)', async () => {
             const { driver } = await getInitialManifest(
@@ -574,7 +577,7 @@ describe('define-remix', () => {
                 },
                 'folder(index)',
             );
-            const { isValid, pageModule, newPageRoute } = driver.getNewPageInfo('about');
+            const { isValid, pageModule, newPageRoute, routingPattern } = driver.getNewPageInfo('about');
             expect(isValid).to.eql(true);
             expect(pageModule).to.eql('/app/routes/about/index.tsx');
             expect(newPageRoute).to.eql(
@@ -585,6 +588,7 @@ describe('define-remix', () => {
                     path: [urlSeg('about')],
                 }),
             );
+            expect(routingPattern).to.eql('folder(index)');
         });
         it('should include parent layouts added because of subpaths, and warn', async () => {
             const aboutLayout = '/app/routes/about.tsx';
@@ -759,7 +763,7 @@ describe('define-remix', () => {
             const { driver } = await getInitialManifest({
                 [aboutPage]: simpleLayout,
             });
-            const { isValid, pageModule, newPageRoute } = driver.getMovePageInfo(aboutPage, 'about2');
+            const { isValid, pageModule, newPageRoute, routingPattern } = driver.getMovePageInfo(aboutPage, 'about2');
             expect(isValid).to.eql(true);
             expect(pageModule).to.eql('/app/routes/about2.tsx');
             expect(newPageRoute).to.eql(
@@ -770,6 +774,7 @@ describe('define-remix', () => {
                     path: [urlSeg('about2')],
                 }),
             );
+            expect(routingPattern).to.eql('file');
         });
     });
 });


### PR DESCRIPTION
This PR adds routing pattern configuration to the `getNewPageInfo` and `getMovePageInfo` functions result, enabling Codux to correctly handle file locations when needed.

Notice that the possible patterns were originally defined as part of `define-remix-app`, but moved to the base `define-app-types` and might need to be expended later to allow more patterns from other frameworks.