### PR TITLE
fix(remix-app): sort routes by readable name

### DIFF
--- a/packages/define-remix-app/src/define-remix-app.tsx
+++ b/packages/define-remix-app/src/define-remix-app.tsx
@@ -453,9 +453,7 @@ export default function defineRemixApp({ appPath, routingPattern = 'file' }: IDe
                 };
 
                 const sortedFilesByRoute = [...routes.entries()].sort(([, a], [, b]) =>
-                    a.path.length === b.path.length
-                        ? a.readableName.localeCompare(b.readableName)
-                        : a.path.length - b.path.length,
+                    a.readableName.localeCompare(b.readableName),
                 );
                 if (rootExportNames.includes('ErrorBoundary')) {
                     const errorRoute = anErrorRoute(

--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -111,6 +111,47 @@ describe('define-remix', () => {
                 ],
             });
         });
+        it('sorts routes by abc', async () => {
+            const aboutPath = '/app/routes/about.tsx';
+            const middlePath = '/app/routes/middle.tsx';
+            const aboutUsPath = '/app/routes/about.us.tsx';
+            const { manifest } = await getInitialManifest({
+                [aboutPath]: simpleLayout,
+                [middlePath]: simpleLayout,
+                [aboutUsPath]: simpleLayout,
+            });
+            expectManifest(manifest, {
+                routes: [
+                    aRoute({
+                        routeId: 'routes/about',
+                        pageModule: aboutPath,
+                        readableUri: 'about',
+                        path: [urlSeg('about')],
+                    }),
+                    aRoute({
+                        routeId: 'routes/about/us',
+                        pageModule: aboutUsPath,
+                        readableUri: 'about/us',
+                        path: [urlSeg('about'), urlSeg('us')],
+                        parentLayouts: [
+                            {
+                                id: 'routes/about',
+                                layoutExportName: 'default',
+                                layoutModule: aboutPath,
+                                path: '/about',
+                                exportNames: ['default'],
+                            },
+                        ],
+                    }),
+                    aRoute({
+                        routeId: 'routes/middle',
+                        pageModule: middlePath,
+                        readableUri: 'middle',
+                        path: [urlSeg('middle')],
+                    }),
+                ],
+            });
+        });
 
         describe('nested routes', () => {
             it(`manifest for: about.tsx, about.us.tsx`, async () => {
@@ -414,6 +455,47 @@ describe('define-remix', () => {
                                 exportNames: ['default'],
                             },
                         ],
+                    }),
+                ],
+            });
+        });
+        it('sorts routes by abc', async () => {
+            const aboutPath = '/app/routes/about/route.tsx';
+            const middlePath = '/app/routes/middle/route.tsx';
+            const aboutUsPath = '/app/routes/about.us/route.tsx';
+            const { manifest } = await getInitialManifest({
+                [aboutPath]: simpleLayout,
+                [middlePath]: simpleLayout,
+                [aboutUsPath]: simpleLayout,
+            });
+            expectManifest(manifest, {
+                routes: [
+                    aRoute({
+                        routeId: 'routes/about/route',
+                        pageModule: aboutPath,
+                        readableUri: 'about',
+                        path: [urlSeg('about')],
+                    }),
+                    aRoute({
+                        routeId: 'routes/about/us/route',
+                        pageModule: aboutUsPath,
+                        readableUri: 'about/us',
+                        path: [urlSeg('about'), urlSeg('us')],
+                        parentLayouts: [
+                            {
+                                id: 'routes/about/route',
+                                layoutExportName: 'default',
+                                layoutModule: aboutPath,
+                                path: '/about',
+                                exportNames: ['default'],
+                            },
+                        ],
+                    }),
+                    aRoute({
+                        routeId: 'routes/middle/route',
+                        pageModule: middlePath,
+                        readableUri: 'middle',
+                        path: [urlSeg('middle')],
                     }),
                 ],
             });


### PR DESCRIPTION
This PR updates the routes sorting logic according to the readable name without taking the path segments amount into account.

This change results in a more intuitive and clearer page order within Codux.

**Before:**
![Screenshot from 2024-09-19 10-59-34](https://github.com/user-attachments/assets/e3a0f290-2771-4040-9f9e-a8510bfb4f18)

**After:**
![Screenshot from 2024-09-19 11-01-11](https://github.com/user-attachments/assets/5ad46b32-06f6-4989-b099-e1b03e141da9)

Notice the previous sorting logic was written for some reason, but there was no comments explaining it and no tests were broken after changing it 🤷🏻
