### PR TITLE
feat: allow react@19.0.0-rc.0 in peer range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6164,8 +6164,8 @@
         "@wixc3/react-board": "^4.0.0"
       },
       "peerDependencies": {
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
+        "react": ">=18.0.0 || ^19.0.0-rc.0",
+        "react-dom": ">=18.0.0 || ^19.0.0-rc.0"
       }
     },
     "packages/board-core": {
@@ -6193,8 +6193,8 @@
         "@wixc3/app-core": "^4.2.0"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "packages/react-board": {
@@ -6205,8 +6205,8 @@
         "@wixc3/board-core": "^4.0.0"
       },
       "peerDependencies": {
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
+        "react": ">=18.0.0 || ^19.0.0-rc.0",
+        "react-dom": ">=18.0.0 || ^19.0.0-rc.0"
       }
     }
   }

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -14,8 +14,8 @@
     }
   },
   "peerDependencies": {
-    "react": ">=18.0.0",
-    "react-dom": ">=18.0.0"
+    "react": ">=18.0.0 || ^19.0.0-rc.0",
+    "react-dom": ">=18.0.0 || ^19.0.0-rc.0"
   },
   "dependencies": {
     "@file-services/types": "^9.4.1",

--- a/packages/define-remix-app/package.json
+++ b/packages/define-remix-app/package.json
@@ -4,8 +4,8 @@
   "version": "4.2.0",
   "main": "dist/index.js",
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "dependencies": {
     "@remix-run/node": "^2.12.0",

--- a/packages/react-board/package.json
+++ b/packages/react-board/package.json
@@ -4,8 +4,8 @@
   "version": "4.0.0",
   "main": "dist/index.js",
   "peerDependencies": {
-    "react": ">=18.0.0",
-    "react-dom": ">=18.0.0"
+    "react": ">=18.0.0 || ^19.0.0-rc.0",
+    "react-dom": ">=18.0.0 || ^19.0.0-rc.0"
   },
   "dependencies": {
     "@wixc3/board-core": "^4.0.0"


### PR DESCRIPTION
prereleases are not included by default for >=18.0.0

define-remix-app uses same range as current remix