### PR TITLE
fix(remix-app): serialize and deserialize both loader and  action

### DIFF
--- a/packages/define-remix-app/src/define-remix-app.tsx
+++ b/packages/define-remix-app/src/define-remix-app.tsx
@@ -248,7 +248,7 @@ export default function defineRemixApp({ appPath, routingPattern = 'file' }: IDe
 
             const res = await requestedMethod(...args);
 
-            if (methodName === 'action' && res instanceof Response) {
+            if ((methodName === 'action' || methodName === 'loader') && res instanceof Response) {
                 return serializeResponse(res);
             }
             if (isDeferredData(res)) {

--- a/packages/define-remix-app/src/manifest-to-router.tsx
+++ b/packages/define-remix-app/src/manifest-to-router.tsx
@@ -272,7 +272,7 @@ function lazyCompAndLoader(
               const res = await callServerMethod(filePath, 'loader', [
                   { params, request: await serializeRequest(request) },
               ]);
-              return res;
+              return deserializeResponse(res as SerializedResponse);
           }
         : undefined;
 

--- a/packages/define-remix-app/src/remix-app-utils.ts
+++ b/packages/define-remix-app/src/remix-app-utils.ts
@@ -278,6 +278,7 @@ export async function serializeResponse(response: Response): Promise<SerializedR
         body = new TextDecoder().decode(streamRes.value);
     }
     return {
+        ...response,
         status: response.status,
         statusText: response.statusText,
         headers: getHeaders(response),
@@ -298,6 +299,7 @@ export function deserializeResponse(response: SerializedResponse) {
         headers.set(key, value);
     });
     return new Response(response.body, {
+        ...response,
         status: response.status,
         statusText: response.statusText,
         headers,


### PR DESCRIPTION
Quick fix to make sure server method call to `loader` is serialized in the same way calls to `action` are.
In addition also add unknown fields to the `serialize/deserialize` utility functions.