### PR TITLE
fix(define-remix-app): apply navigation method when starting from an error boundary

### DIFF
--- a/packages/define-remix-app/src/manifest-to-router.tsx
+++ b/packages/define-remix-app/src/manifest-to-router.tsx
@@ -286,12 +286,7 @@ function lazyCompAndLoader(
               };
               return {
                   default: () => (
-                      <ErrorPage
-                          filePath={filePath}
-                          isRootFile={isRootFile}
-                          moduleWithComp={moduleWithComp}
-                          onCaughtError={onCaughtError}
-                      />
+                      <ErrorPage filePath={filePath} moduleWithComp={moduleWithComp} onCaughtError={onCaughtError} />
                   ),
               };
           })
@@ -340,7 +335,6 @@ function useDispatcher<T>(dispatcher: Dispatcher<T>) {
 function ErrorPage({
     moduleWithComp,
     filePath,
-    isRootFile,
     onCaughtError,
 }: {
     moduleWithComp: {
@@ -348,7 +342,6 @@ function ErrorPage({
     };
     onCaughtError: ErrorReporter;
     filePath: string;
-    isRootFile: boolean;
 }) {
     navigation.setNavigateFunction(useNavigate());
 
@@ -357,8 +350,5 @@ function ErrorPage({
         return <moduleWithComp.ErrorBoundary />;
     }
 
-    if (!isRootFile) {
-        throw new Error(`ErrorBoundary not found at ${filePath}`);
-    }
     return <div>error boundary not found at {filePath}</div>;
 }

--- a/packages/define-remix-app/src/manifest-to-router.tsx
+++ b/packages/define-remix-app/src/manifest-to-router.tsx
@@ -285,16 +285,14 @@ function lazyCompAndLoader(
                   ErrorBoundary?: React.ComponentType;
               };
               return {
-                  default: () => {
-                      if (moduleWithComp.ErrorBoundary) {
-                          onCaughtError({ filePath, exportName: 'ErrorBoundary' });
-                          return <moduleWithComp.ErrorBoundary />;
-                      }
-                      if (!isRootFile) {
-                          throw new Error(`ErrorBoundary not found at ${filePath}`);
-                      }
-                      return <div>error boundary not found at {filePath}</div>;
-                  },
+                  default: () => (
+                      <ErrorPage
+                          filePath={filePath}
+                          isRootFile={isRootFile}
+                          moduleWithComp={moduleWithComp}
+                          onCaughtError={onCaughtError}
+                      />
+                  ),
               };
           })
         : undefined;
@@ -337,4 +335,30 @@ function useDispatcher<T>(dispatcher: Dispatcher<T>) {
         return dispatcher.subscribe(setState);
     }, [dispatcher]);
     return state;
+}
+
+function ErrorPage({
+    moduleWithComp,
+    filePath,
+    isRootFile,
+    onCaughtError,
+}: {
+    moduleWithComp: {
+        ErrorBoundary?: React.ComponentType;
+    };
+    onCaughtError: ErrorReporter;
+    filePath: string;
+    isRootFile: boolean;
+}) {
+    navigation.setNavigateFunction(useNavigate());
+
+    if (moduleWithComp.ErrorBoundary) {
+        onCaughtError({ filePath, exportName: 'ErrorBoundary' });
+        return <moduleWithComp.ErrorBoundary />;
+    }
+
+    if (!isRootFile) {
+        throw new Error(`ErrorBoundary not found at ${filePath}`);
+    }
+    return <div>error boundary not found at {filePath}</div>;
 }

--- a/packages/define-remix-app/src/page-template.ts
+++ b/packages/define-remix-app/src/page-template.ts
@@ -20,7 +20,7 @@ return params;
 const ${compIdentifier} = () => {
 const params = useLoaderData<typeof loader>();
 return <div>
-${[...varNames].map((name) => `<div>${clearJsxSpecialCharactersFromText(name)}: {params["${name}}"]</div>`).join('\n')}
+${[...varNames].map((name) => `<div>${clearJsxSpecialCharactersFromText(name)}: {params["${name}"]}</div>`).join('\n')}
 </div>;
 };
 export default ${compIdentifier};


### PR DESCRIPTION
We used to initialize the navigation method when the RootComponent renders, now we initialize it when we start on an error boundary as well (where RootComp isn't rendered).

Also fixed the dynamic page template.