### PR TITLE
fix(remix-app): remove $ from page comp name

### DIFF
--- a/packages/define-remix-app/src/page-template.ts
+++ b/packages/define-remix-app/src/page-template.ts
@@ -33,5 +33,5 @@ function clearJsxSpecialCharactersFromText(txt: string) {
     return txt.replace(/[{}<>]/g, '');
 }
 function cleanInvalidJsIdentChars(txt: string) {
-    return txt.replace(/[!@#%^&*()\-+=[\]{}|;:'",.<>?/~\\`\s]/g, '');
+    return txt.replace(/[$!@#%^&*()\-+=[\]{}|;:'",.<>?/~\\`\s]/g, '');
 }

--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -807,7 +807,7 @@ describe('define-remix', () => {
                 });
                 const { newPageSourceCode } = driver.getNewPageInfo('Abou#$t');
 
-                expect(newPageSourceCode, 'Capital letter').to.include('export default function About() {');
+                expect(newPageSourceCode).to.include('export default function About() {');
             });
             it('should cleanup initial JSX content', async () => {
                 const { driver } = await getInitialManifest({

--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -805,7 +805,7 @@ describe('define-remix', () => {
                 const { driver } = await getInitialManifest({
                     [indexPath]: simpleLayout,
                 });
-                const { newPageSourceCode } = driver.getNewPageInfo('Abou#t');
+                const { newPageSourceCode } = driver.getNewPageInfo('Abou#$t');
 
                 expect(newPageSourceCode, 'Capital letter').to.include('export default function About() {');
             });


### PR DESCRIPTION
This PR resolves an issue where a page name containing `$` would cause problems. The newly created component name is now normalized to remove the invalid `$` character, ensuring it adheres to valid naming conventions.