### PR TITLE
fix(define-remix-app): use `toPascalCaseJsIdentifier` for formatting the component identifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1283,6 +1283,14 @@
       "resolved": "packages/board-plugins",
       "link": true
     },
+    "node_modules/@wixc3/common": {
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@wixc3/common/-/common-17.1.1.tgz",
+      "integrity": "sha512-IB448WzOJTl7Sehck105dm6c1+CJK5A/zdhu6fnUCUADNgWH3kEU03x+WpHy2QnWzkS77iR2T7ZZJVF4kiKUHQ==",
+      "dependencies": {
+        "promise-assist": "^2.0.1"
+      }
+    },
     "node_modules/@wixc3/create-disposables": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@wixc3/create-disposables/-/create-disposables-2.2.0.tgz",
@@ -4736,7 +4744,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-assist/-/promise-assist-2.0.1.tgz",
       "integrity": "sha512-hKLG+bqLZt7WjuGqgwa12pWyph23bEiqYR16WCnZQxpuveDBABKP4tRcSdMWlxIcEBN0MLsUs+VBH+TlaIHtgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -6201,7 +6208,8 @@
         "@remix-run/react": "^2.12.1",
         "@remix-run/router": "^1.19.2",
         "@remix-run/testing": "^2.12.1",
-        "@wixc3/app-core": "^4.3.2"
+        "@wixc3/app-core": "^4.3.2",
+        "@wixc3/common": "^17.1.1"
       },
       "peerDependencies": {
         "react": "^18.0.0",

--- a/packages/define-remix-app/package.json
+++ b/packages/define-remix-app/package.json
@@ -12,7 +12,8 @@
     "@remix-run/react": "^2.12.1",
     "@remix-run/router": "^1.19.2",
     "@remix-run/testing": "^2.12.1",
-    "@wixc3/app-core": "^4.3.2"
+    "@wixc3/app-core": "^4.3.2",
+    "@wixc3/common": "^17.1.1"
   },
   "files": [
     "dist",

--- a/packages/define-remix-app/src/page-template.ts
+++ b/packages/define-remix-app/src/page-template.ts
@@ -33,5 +33,5 @@ function clearJsxSpecialCharactersFromText(txt: string) {
     return txt.replace(/[{}<>]/g, '');
 }
 function cleanInvalidJsIdentChars(txt: string) {
-    return txt.replace(/[!@#%^&*()\-+=[\]{}|;:'",.<>?/~\\`\s]/g, '');
+    return txt.replace(/[!@#%^&*()\-+=[\]{}|;:'",.$<>?/~\\`\s]/g, '');
 }

--- a/packages/define-remix-app/src/page-template.ts
+++ b/packages/define-remix-app/src/page-template.ts
@@ -1,5 +1,7 @@
+import { toPascalCaseJsIdentifier } from '@wixc3/common';
+
 export const pageTemplate = (pageName: string, varNames: Set<string>) => {
-    const compIdentifier = cleanInvalidJsIdentChars(pageName[0].toUpperCase() + pageName.slice(1));
+    const compIdentifier = toPascalCaseJsIdentifier(pageName[0]);
     return varNames.size === 0
         ? `
 import React from 'react';
@@ -31,7 +33,4 @@ export default ${compIdentifier};
 
 function clearJsxSpecialCharactersFromText(txt: string) {
     return txt.replace(/[{}<>]/g, '');
-}
-function cleanInvalidJsIdentChars(txt: string) {
-    return txt.replace(/[!@#%^&*()\-+=[\]{}|;:'",.$<>?/~\\`\s]/g, '');
 }


### PR DESCRIPTION
This fixes an issue where component identifier included the '$' sign when creating a dynamic page.

For example: `MyPage/$param` created a `MyPage$param` component.

This PR adds a dependency on `@wixc3/common` to the `define-remix-app` package and uses `toPascalCaseJsIdentifier` for formatting the component identifier.