### PR TITLE
fix(define-remix-app): fix page template to include an import to the LoaderFunctionArgs interface

### DIFF
--- a/packages/define-remix-app/src/page-template.ts
+++ b/packages/define-remix-app/src/page-template.ts
@@ -13,11 +13,11 @@ import { useLoaderData } from "@remix-run/react";
 import type { LoaderFunctionArgs } from '@remix-run/node';
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
-    return params;
+    return { params };
 };
 
 const ${compIdentifier} = () => {
-    const params = useLoaderData<typeof loader>();
+    const { params } = useLoaderData<typeof loader>();
     return <div>
         ${[...varNames].map((name) => `<div>${clearJsxSpecialCharactersFromText(name)}: {params["${name}"]}</div>`).join('\n')}
         </div>;

--- a/packages/define-remix-app/src/page-template.ts
+++ b/packages/define-remix-app/src/page-template.ts
@@ -10,22 +10,21 @@ return <div>${clearJsxSpecialCharactersFromText(pageName)}</div>;
         : `
 import React from 'react';
 import { useLoaderData } from "@remix-run/react";
+import type { LoaderFunctionArgs } from '@remix-run/node';
 
-export const loader = async (params: { 
-${[...varNames].map((name) => `${name}: string`).join(',\n')}
-}) => {
-return params;
+export const loader = async ({ params }: LoaderFunctionArgs) => {
+    return params;
 };
 
 const ${compIdentifier} = () => {
-const params = useLoaderData<typeof loader>();
-return <div>
-${[...varNames].map((name) => `<div>${clearJsxSpecialCharactersFromText(name)}: {params["${name}"]}</div>`).join('\n')}
-</div>;
+    const params = useLoaderData<typeof loader>();
+    return <div>
+        ${[...varNames].map((name) => `<div>${clearJsxSpecialCharactersFromText(name)}: {params["${name}"]}</div>`).join('\n')}
+        </div>;
 };
+
 export default ${compIdentifier};
   
-        
         `;
 };
 


### PR DESCRIPTION
use `LoaderFunctionArgs`instead of an inline object and destructure params on usage.