### PR TITLE
support navigation to hash url

### DIFF
--- a/packages/define-remix-app/src/define-remix-app.tsx
+++ b/packages/define-remix-app/src/define-remix-app.tsx
@@ -34,6 +34,7 @@ import { parentLayoutWarning } from './content';
 import { pageTemplate } from './page-template';
 import { isDeferredData } from '@remix-run/router';
 import { json } from '@remix-run/node';
+import { Navigation } from './navigation';
 export interface IDefineRemixAppProps {
     appPath: string;
     bookmarks?: string[];
@@ -52,6 +53,7 @@ export const INVALID_MSGS = {
 export default function defineRemixApp({ appPath, routingPattern = 'file' }: IDefineRemixAppProps) {
     let rootLayouts: RouteExtraInfo['parentLayouts'] = [];
     let layoutMap: Map<string, ParentLayoutWithExtra> = new Map();
+    const navigation = new Navigation();
     const getRouteLayouts = (filePathInRouteDir: string, fsApi: FSApi, layouts = layoutMap) => {
         const parentLayouts: RouteExtraInfo['parentLayouts'] = [...rootLayouts];
         const routeLayouts = filePathToLayoutMatching(filePathInRouteDir, fsApi.path);
@@ -205,8 +207,17 @@ export default function defineRemixApp({ appPath, routingPattern = 'file' }: IDe
         }: IReactAppProps<RouteExtraInfo>) => {
             const uriRef = useRef(uri);
             uriRef.current = uri;
-            const { Router, navigate } = useMemo(
-                () => manifestToRouter(manifest, importModule, setUri, onCaughtError, uriRef, callServerMethod),
+            const { Router } = useMemo(
+                () =>
+                    manifestToRouter(
+                        manifest,
+                        navigation,
+                        importModule,
+                        setUri,
+                        onCaughtError,
+                        uriRef,
+                        callServerMethod,
+                    ),
                 [manifest, importModule, setUri, onCaughtError, callServerMethod],
             );
 
@@ -214,8 +225,8 @@ export default function defineRemixApp({ appPath, routingPattern = 'file' }: IDe
                 return clearLoadedModules;
             }, []);
             useEffect(() => {
-                navigate(uri.startsWith('/') ? uri : `/${uri}`);
-            }, [uri, navigate]);
+                navigation.navigate(uri.startsWith('/') ? uri : `/${uri}`);
+            }, [uri]);
 
             return (
                 <Router

--- a/packages/define-remix-app/src/manifest-to-router.tsx
+++ b/packages/define-remix-app/src/manifest-to-router.tsx
@@ -115,9 +115,6 @@ export const manifestToRouter = (
 
     return {
         Router,
-        navigate(path: string) {
-            navigation.navigate(path);
-        },
     };
 };
 const loadedModules = new Map<string, RouteObject>();
@@ -156,17 +153,6 @@ export const fileToRoute = (
     return module;
 };
 
-const locationToUri = (location: Location) => {
-    let uri = location.pathname;
-    if (location.search) {
-        uri += location.search;
-    }
-    if (location.hash) {
-        uri += location.hash;
-    }
-    return uri;
-};
-
 function RootComp({
     module,
     navigation,
@@ -183,9 +169,9 @@ function RootComp({
     const currentModule = useDispatcher(module);
     navigation.setNavigateFunction(useNavigate());
 
-    const location = useLocation();
+    const { pathname, search = '', hash = '' } = useLocation();
+    const uri = `${pathname}${search}${hash}`;
 
-    const uri = locationToUri(location);
     useEffect(() => {
         if (uri.slice(1) !== prevUri.current) {
             setUri(uri.slice(1));

--- a/packages/define-remix-app/src/navigation.ts
+++ b/packages/define-remix-app/src/navigation.ts
@@ -1,6 +1,6 @@
 import { NavigateFunction } from '@remix-run/react';
 
-class Navigation {
+export class Navigation {
     private navigateFunction?: NavigateFunction;
 
     navigate(path: string) {
@@ -12,4 +12,3 @@ class Navigation {
     }
 }
 
-export const navigation = new Navigation();


### PR DESCRIPTION
This PR changes the navigation to include the `search` and the `hash` alongside `pathname` in the navigation uri.