### PR TITLE
feat(define-remix-app): update loader on change

### DIFF
--- a/packages/app-core/test-kit/index.ts
+++ b/packages/app-core/test-kit/index.ts
@@ -134,10 +134,13 @@ export class AppDefDriver<T> {
             listener(this.lastManifest!);
         }
     }
-    async render({uri = '/'}: {uri?: string} = {}) {
+    async render({
+        uri = '/',
+        testAutoRerenderOnManifestUpdate,
+    }: { uri?: string; testAutoRerenderOnManifestUpdate?: boolean } = {}) {
         const { app } = this.options;
         const { fsApi, importModule } = this;
-            
+
         if (!app.callServerMethod) {
             throw new Error('app.callServerMethod is not defined');
         }
@@ -171,7 +174,9 @@ export class AppDefDriver<T> {
         const manifestListener = () => {
             void rerender({uri: lastUri});
         };
-        this.addManifestListener(manifestListener);
+        if (testAutoRerenderOnManifestUpdate !== false) {
+            this.addManifestListener(manifestListener);
+        }
         return {
             dispose: ()=> {
                 unmount();

--- a/packages/define-remix-app/test/test-cases/roots.ts
+++ b/packages/define-remix-app/test/test-cases/roots.ts
@@ -145,6 +145,34 @@ export const rootWithLayout2 = transformTsx(`
         return <div>Error</div>;
     }
 `);
+export const rootWithLayoutAndLoader = transformTsx(`
+    import React from 'react';
+    import { Outlet, Links } from '@remix-run/react';
+
+    export function Layout({ children }: { children: React.ReactNode }) {
+        return (
+            <mock-ml lang="en">
+                <mock-header><Links/></mock-header>
+                <mock-body>
+                    Layout|
+                    {children}
+                </mock-body>
+            </mock-ml>
+        );
+    }
+    export default function App() {
+        return (
+            <div>
+                App|
+                <Outlet />
+            </div>
+        );
+    }
+
+    export function ErrorBoundary({ error }: { error: Error }) {
+        return <div>Error</div>;
+    }
+`);
 export const withHandle = (originalSrc: string, name: string) => {
     return `
     ${originalSrc}
@@ -277,7 +305,46 @@ export const loaderAndClientLoaderPage = (name: string, message: string, clientM
     }
 `);
 
-export const clientLoaderWithFallbackPage = (name: string,  clientMessage: string) =>
+export const loaderAndClientLoaderRoot = (serverLoaderMsg: string, clientLoaderMsg: string) =>
+    transformTsx(`
+    import React from 'react';
+    import { Outlet, Links, useLoaderData, json } from '@remix-run/react';
+
+    export const clientLoader = async ({serverLoader}) => {
+        const serverResponse = await serverLoader();
+        const serverData = await serverResponse.json();
+        return { clientMessage: '${clientLoaderMsg}', ...serverData }
+    };
+    clientLoader.hydrate = true;
+    export const loader = () => (json({ serverMessage: '${serverLoaderMsg}' }));
+
+    export function Layout({ children }: { children: React.ReactNode }) {
+        return (
+            <mock-ml lang="en">
+                <mock-header><Links/></mock-header>
+                <mock-body>
+                    Layout|
+                    {children}
+                </mock-body>
+            </mock-ml>
+        );
+    }
+    export default function App() {
+        const data = useLoaderData();
+        return (
+            <div>
+                App:{data.serverMessage}!{data.clientMessage}|
+                <Outlet />
+            </div>
+        );
+    }
+
+    export function ErrorBoundary({ error }: { error: Error }) {
+        return <div>Error</div>;
+    }
+`);
+
+export const clientLoaderWithFallbackPage = (name: string, clientMessage: string) =>
     transformTsx(`
     import React from 'react';
     import { Outlet, useLoaderData } from '@remix-run/react';

--- a/packages/define-remix-app/test/test-cases/roots.ts
+++ b/packages/define-remix-app/test/test-cases/roots.ts
@@ -145,34 +145,6 @@ export const rootWithLayout2 = transformTsx(`
         return <div>Error</div>;
     }
 `);
-export const rootWithLayoutAndLoader = transformTsx(`
-    import React from 'react';
-    import { Outlet, Links } from '@remix-run/react';
-
-    export function Layout({ children }: { children: React.ReactNode }) {
-        return (
-            <mock-ml lang="en">
-                <mock-header><Links/></mock-header>
-                <mock-body>
-                    Layout|
-                    {children}
-                </mock-body>
-            </mock-ml>
-        );
-    }
-    export default function App() {
-        return (
-            <div>
-                App|
-                <Outlet />
-            </div>
-        );
-    }
-
-    export function ErrorBoundary({ error }: { error: Error }) {
-        return <div>Error</div>;
-    }
-`);
 export const withHandle = (originalSrc: string, name: string) => {
     return `
     ${originalSrc}


### PR DESCRIPTION
This PR makes sure both page and root components are updated when a page/root module updates.

The solution here is to update the data using the [Remix revlalidator api](https://remix.run/docs/en/main/hooks/use-revalidator) each time a page/root module is changed without knowing if the loader actually changed.

Additionally, an option was added to the test driver to prevent automatic re-renders during the 
`prepareApp -> onManifestUpdate` call in order to validate that module update invalidates the loaders with no external integration.