### PR TITLE
moved extra data to root to enable supporting fetchers from api routes

### DIFF
--- a/packages/app-core/src/define-app-types.ts
+++ b/packages/app-core/src/define-app-types.ts
@@ -87,7 +87,7 @@ export interface FSApi {
     path: PathApi;
 }
 
-export interface IReactApp<T = unknown> {
+export interface IReactApp<T = unknown, U = unknown> {
     /**
      * Should be isomorphic, should return the same result on the server and in a web worker
      * returns the app manifest containing a list of routes for the app.
@@ -95,7 +95,7 @@ export interface IReactApp<T = unknown> {
      * should call onManifestUpdate when the manifest is updated
      */
     prepareApp: (options: IPrepareAppOptions) => Promise<{
-        manifest: IAppManifest<T>;
+        manifest: IAppManifest<T, U>;
         dispose: () => void;
     }>;
 
@@ -106,7 +106,7 @@ export interface IReactApp<T = unknown> {
      * returns the information needed to create a new page
      *
      */
-    getNewPageInfo?: (options: IGetNewPageInfoOptions<T>) => {
+    getNewPageInfo?: (options: IGetNewPageInfoOptions<T, U>) => {
         isValid: boolean;
         errorMessage?: string;
         warningMessage?: string;
@@ -121,7 +121,7 @@ export interface IReactApp<T = unknown> {
      *
      * returns the information needed to move a page
      */
-    getMovePageInfo?: (options: IMovePageInfoOptions<T>) => {
+    getMovePageInfo?: (options: IMovePageInfoOptions<T, U>) => {
         isValid: boolean;
         errorMessage?: string;
         warningMessage?: string;
@@ -151,16 +151,16 @@ export interface IReactApp<T = unknown> {
      */
     hasGetStaticRoutes?: (options: ICallServerMethodOptions, forRouteAtFilePath: string) => Promise<boolean>;
 
-
-    App: React.ComponentType<IReactAppProps<T>>;
+    App: React.ComponentType<IReactAppProps<T, U>>;
     /**
      * Renders the App into an HTML element
      *
      * @returns a cleanup function
      */
-    render: (targetElement: HTMLElement, props: IReactAppProps<T>) => Promise<() => void>;
+    render: (targetElement: HTMLElement, props: IReactAppProps<T, U>) => Promise<() => void>;
 }
-export interface IAppManifest<T = unknown> {
+export interface IAppManifest<T = unknown, U = undefined> {
+    extraData: U;
     routes: RouteInfo<T>[];
     homeRoute?: RouteInfo<T>;
     errorRoutes?: RouteInfo<T>[];
@@ -183,7 +183,6 @@ export interface RouteInfo<T = unknown> {
      */
     hasGetStaticRoutes?: boolean;
 
- 
     /**
      * a list of export names of the page that should be editable
      * if the page is a function, the UI will edit its return value
@@ -215,8 +214,8 @@ export interface DynamicRoutePart {
     name: string;
 }
 
-export interface IReactAppProps<T = unknown> {
-    manifest: IAppManifest<T>;
+export interface IReactAppProps<T = unknown, U = unknown> {
+    manifest: IAppManifest<T, U>;
     importModule: DynamicImport;
     uri: string;
     setUri: (uri: string) => void;
@@ -236,22 +235,22 @@ export type DynamicImport = (
 
 export interface IPrepareAppOptions {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    onManifestUpdate: (appProps: IAppManifest<any>) => void;
+    onManifestUpdate: (appProps: IAppManifest<any, any>) => void;
     fsApi: FSApi;
 }
 export interface ICallServerMethodOptions {
     fsApi: FSApi;
     importModule: DynamicImport;
 }
-export interface IGetNewPageInfoOptions<T> {
+export interface IGetNewPageInfoOptions<T, U> {
     fsApi: FSApi;
     requestedURI: string;
-    manifest: IAppManifest<T>;
+    manifest: IAppManifest<T, U>;
 }
 
 export type RoutingPattern = 'file' | 'folder(route)' | 'folder(index)';
 
-export interface IMovePageInfoOptions<T> extends IGetNewPageInfoOptions<T> {
+export interface IMovePageInfoOptions<T, U> extends IGetNewPageInfoOptions<T, U> {
     movedFilePath: string;
 }
 export interface EditablePointOfInterest {
@@ -265,4 +264,5 @@ export interface IResults<T> {
     errorMessage?: string;
 }
 
-export type OmitReactApp<T extends IReactApp<D>, D> = Omit<T, 'render' | 'setupStage' | 'setProps'>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type OmitReactApp<T extends IReactApp<any, any>> = Omit<T, 'render' | 'setupStage' | 'setProps'>;

--- a/packages/app-core/src/define-app-types.ts
+++ b/packages/app-core/src/define-app-types.ts
@@ -87,7 +87,7 @@ export interface FSApi {
     path: PathApi;
 }
 
-export interface IReactApp<T = unknown, U = unknown> {
+export interface IReactApp<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = unknown> {
     /**
      * Should be isomorphic, should return the same result on the server and in a web worker
      * returns the app manifest containing a list of routes for the app.
@@ -95,7 +95,7 @@ export interface IReactApp<T = unknown, U = unknown> {
      * should call onManifestUpdate when the manifest is updated
      */
     prepareApp: (options: IPrepareAppOptions) => Promise<{
-        manifest: IAppManifest<T, U>;
+        manifest: IAppManifest<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA>;
         dispose: () => void;
     }>;
 
@@ -106,13 +106,13 @@ export interface IReactApp<T = unknown, U = unknown> {
      * returns the information needed to create a new page
      *
      */
-    getNewPageInfo?: (options: IGetNewPageInfoOptions<T, U>) => {
+    getNewPageInfo?: (options: IGetNewPageInfoOptions<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA>) => {
         isValid: boolean;
         errorMessage?: string;
         warningMessage?: string;
         pageModule: string;
         newPageSourceCode: string;
-        newPageRoute?: RouteInfo<T>;
+        newPageRoute?: RouteInfo<ROUTE_EXTRA_DATA>;
         routingPattern?: RoutingPattern;
     };
 
@@ -121,12 +121,12 @@ export interface IReactApp<T = unknown, U = unknown> {
      *
      * returns the information needed to move a page
      */
-    getMovePageInfo?: (options: IMovePageInfoOptions<T, U>) => {
+    getMovePageInfo?: (options: IMovePageInfoOptions<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA>) => {
         isValid: boolean;
         errorMessage?: string;
         warningMessage?: string;
         pageModule: string;
-        newPageRoute?: RouteInfo<T>;
+        newPageRoute?: RouteInfo<ROUTE_EXTRA_DATA>;
         routingPattern?: RoutingPattern;
     };
     /**
@@ -151,22 +151,25 @@ export interface IReactApp<T = unknown, U = unknown> {
      */
     hasGetStaticRoutes?: (options: ICallServerMethodOptions, forRouteAtFilePath: string) => Promise<boolean>;
 
-    App: React.ComponentType<IReactAppProps<T, U>>;
+    App: React.ComponentType<IReactAppProps<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA>>;
     /**
      * Renders the App into an HTML element
      *
      * @returns a cleanup function
      */
-    render: (targetElement: HTMLElement, props: IReactAppProps<T, U>) => Promise<() => void>;
+    render: (
+        targetElement: HTMLElement,
+        props: IReactAppProps<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA>,
+    ) => Promise<() => void>;
 }
-export interface IAppManifest<T = unknown, U = undefined> {
-    extraData: U;
-    routes: RouteInfo<T>[];
-    homeRoute?: RouteInfo<T>;
-    errorRoutes?: RouteInfo<T>[];
+export interface IAppManifest<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = undefined> {
+    extraData: MANIFEST_EXTRA_DATA;
+    routes: RouteInfo<ROUTE_EXTRA_DATA>[];
+    homeRoute?: RouteInfo<ROUTE_EXTRA_DATA>;
+    errorRoutes?: RouteInfo<ROUTE_EXTRA_DATA>[];
 }
 
-export interface RouteInfo<T = unknown> {
+export interface RouteInfo<ROUTE_EXTRA_DATA = unknown> {
     pageModule: string;
     pageExportName?: string;
     /**
@@ -194,7 +197,7 @@ export interface RouteInfo<T = unknown> {
     /**
      * any extra data that should be passed to the App component
      */
-    extraData: T;
+    extraData: ROUTE_EXTRA_DATA;
     path: Array<StaticRoutePart | DynamicRoutePart>;
     /**
      * readable (and editable) text representation of the path
@@ -214,8 +217,8 @@ export interface DynamicRoutePart {
     name: string;
 }
 
-export interface IReactAppProps<T = unknown, U = unknown> {
-    manifest: IAppManifest<T, U>;
+export interface IReactAppProps<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = unknown> {
+    manifest: IAppManifest<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA>;
     importModule: DynamicImport;
     uri: string;
     setUri: (uri: string) => void;
@@ -242,15 +245,16 @@ export interface ICallServerMethodOptions {
     fsApi: FSApi;
     importModule: DynamicImport;
 }
-export interface IGetNewPageInfoOptions<T, U> {
+export interface IGetNewPageInfoOptions<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = unknown> {
     fsApi: FSApi;
     requestedURI: string;
-    manifest: IAppManifest<T, U>;
+    manifest: IAppManifest<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA>;
 }
 
 export type RoutingPattern = 'file' | 'folder(route)' | 'folder(index)';
 
-export interface IMovePageInfoOptions<T, U> extends IGetNewPageInfoOptions<T, U> {
+export interface IMovePageInfoOptions<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = unknown>
+    extends IGetNewPageInfoOptions<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA> {
     movedFilePath: string;
 }
 export interface EditablePointOfInterest {

--- a/packages/app-core/src/define-app.tsx
+++ b/packages/app-core/src/define-app.tsx
@@ -1,8 +1,8 @@
 import { reactErrorHandledRendering } from '@wixc3/react-board/dist/react-error-handled-render';
 import { IReactApp, OmitReactApp } from './define-app-types';
 
-export function defineApp<T>(input: OmitReactApp<IReactApp<T>, T>): IReactApp<T> {
-    const res: IReactApp<T> = {
+export function defineApp<T, U>(input: OmitReactApp<IReactApp<T, U>>): IReactApp<T, U> {
+    const res: IReactApp<T, U> = {
         ...input,
 
         async render(target, appProps) {

--- a/packages/app-core/src/define-app.tsx
+++ b/packages/app-core/src/define-app.tsx
@@ -1,8 +1,10 @@
 import { reactErrorHandledRendering } from '@wixc3/react-board/dist/react-error-handled-render';
 import { IReactApp, OmitReactApp } from './define-app-types';
 
-export function defineApp<T, U>(input: OmitReactApp<IReactApp<T, U>>): IReactApp<T, U> {
-    const res: IReactApp<T, U> = {
+export function defineApp<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = undefined>(
+    input: OmitReactApp<IReactApp<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA>>,
+): IReactApp<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA> {
+    const res: IReactApp<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA> = {
         ...input,
 
         async render(target, appProps) {

--- a/packages/app-core/test-kit/index.ts
+++ b/packages/app-core/test-kit/index.ts
@@ -4,8 +4,8 @@ import { createMemoryFs, IMemFileSystem } from '@file-services/memory';
 import { createRequestResolver } from '@file-services/resolve';
 import path from '@file-services/path';
 import { IDirectoryContents } from '@file-services/types';
-export interface AppDefDriverOptions<T, U> {
-    app: IReactApp<T, U>;
+export interface AppDefDriverOptions<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATAU = unknown> {
+    app: IReactApp<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATAU>;
     initialFiles: IDirectoryContents;
     evaluatedNodeModules: Record<string, unknown>;
     /**
@@ -18,16 +18,16 @@ export interface AppDefDriverOptions<T, U> {
     projectPath?: string;
 }
 type DirListenerObj = { cb: (files: string[]) => void; dirPath: string };
-export class AppDefDriver<T, U> {
+export class AppDefDriver<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = unknown> {
     private fs: IMemFileSystem;
     private moduleSystem: ICommonJsModuleSystem;
     private dirListeners: Array<DirListenerObj> = [];
-    private manifestListeners: Set<(manifest: IAppManifest<T, U>) => void> = new Set();
+    private manifestListeners: Set<(manifest: IAppManifest<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA>) => void> = new Set();
     private fileListeners: Record<string, Set<(contents: string | null) => void>> = {};
     private exportsListeners: Record<string, Set<(exportNames: string[]) => void>> = {};
-    private lastManifest: IAppManifest<T, U> | null = null;
+    private lastManifest: IAppManifest<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA> | null = null;
     private disposeApp?: () => void;
-    constructor(private options: AppDefDriverOptions<T, U>) {
+    constructor(private options: AppDefDriverOptions<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA>) {
         this.fs = createMemoryFs(options.initialFiles);
         const resolver = createRequestResolver({ fs: this.fs });
         this.moduleSystem = createBaseCjsModuleSystem({
@@ -123,10 +123,10 @@ export class AppDefDriver<T, U> {
             movedFilePath,
         });
     }
-    addManifestListener(cb: (manifest: IAppManifest<T, U>) => void) {
+    addManifestListener(cb: (manifest: IAppManifest<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA>) => void) {
         this.manifestListeners.add(cb);
     }
-    removeManifestListener(cb: (manifest: IAppManifest<T, U>) => void) {
+    removeManifestListener(cb: (manifest: IAppManifest<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA>) => void) {
         this.manifestListeners.delete(cb);
     }
     private dispatchManifestUpdate() {

--- a/packages/app-core/test-kit/index.ts
+++ b/packages/app-core/test-kit/index.ts
@@ -4,10 +4,10 @@ import { createMemoryFs, IMemFileSystem } from '@file-services/memory';
 import { createRequestResolver } from '@file-services/resolve';
 import path from '@file-services/path';
 import { IDirectoryContents } from '@file-services/types';
-export interface AppDefDriverOptions<T> {
-    app: IReactApp<T>;
+export interface AppDefDriverOptions<T, U> {
+    app: IReactApp<T, U>;
     initialFiles: IDirectoryContents;
-    evaluatedNodeModules: Record<string, unknown>
+    evaluatedNodeModules: Record<string, unknown>;
     /**
      * @default '/app-def.ts'
      */
@@ -18,22 +18,22 @@ export interface AppDefDriverOptions<T> {
     projectPath?: string;
 }
 type DirListenerObj = { cb: (files: string[]) => void; dirPath: string };
-export class AppDefDriver<T> {
+export class AppDefDriver<T, U> {
     private fs: IMemFileSystem;
     private moduleSystem: ICommonJsModuleSystem;
     private dirListeners: Array<DirListenerObj> = [];
-    private manifestListeners: Set<(manifest: IAppManifest<T>) => void> = new Set();
+    private manifestListeners: Set<(manifest: IAppManifest<T, U>) => void> = new Set();
     private fileListeners: Record<string, Set<(contents: string | null) => void>> = {};
     private exportsListeners: Record<string, Set<(exportNames: string[]) => void>> = {};
-    private lastManifest: IAppManifest<T> | null = null;
+    private lastManifest: IAppManifest<T, U> | null = null;
     private disposeApp?: () => void;
-    constructor(private options: AppDefDriverOptions<T>) {
+    constructor(private options: AppDefDriverOptions<T, U>) {
         this.fs = createMemoryFs(options.initialFiles);
-        const resolver = createRequestResolver({fs: this.fs});
+        const resolver = createRequestResolver({ fs: this.fs });
         this.moduleSystem = createBaseCjsModuleSystem({
             dirname: this.fs.dirname,
             readFileSync: (filePath) => {
-                const fileContents = this.fs.readFileSync(filePath, {encoding: 'utf8'});
+                const fileContents = this.fs.readFileSync(filePath, { encoding: 'utf8' });
                 if (typeof fileContents !== 'string') {
                     throw new Error(`No content for: ${filePath}`);
                 }
@@ -44,7 +44,7 @@ export class AppDefDriver<T> {
                     return request;
                 }
                 const resolved = resolver(contextPath, request);
-                return resolved.resolvedFile
+                return resolved.resolvedFile;
             },
             globals: {},
         });
@@ -73,7 +73,7 @@ export class AppDefDriver<T> {
     addOrUpdateFile(filePath: string, contents: string) {
         const existingFile = !!this.fs.existsSync(filePath);
         this.fs.writeFileSync(filePath, contents);
-        
+
         if (!existingFile) {
             for (const listener of this.dirListeners) {
                 if (filePath.startsWith(listener.dirPath)) {
@@ -123,10 +123,10 @@ export class AppDefDriver<T> {
             movedFilePath,
         });
     }
-    addManifestListener(cb: (manifest: IAppManifest<T>) => void) {
+    addManifestListener(cb: (manifest: IAppManifest<T, U>) => void) {
         this.manifestListeners.add(cb);
     }
-    removeManifestListener(cb: (manifest: IAppManifest<T>) => void) {
+    removeManifestListener(cb: (manifest: IAppManifest<T, U>) => void) {
         this.manifestListeners.delete(cb);
     }
     private dispatchManifestUpdate() {
@@ -134,10 +134,10 @@ export class AppDefDriver<T> {
             listener(this.lastManifest!);
         }
     }
-    async render({uri = '/'}: {uri?: string} = {}) {
+    async render({ uri = '/' }: { uri?: string } = {}) {
         const { app } = this.options;
         const { fsApi, importModule } = this;
-            
+
         if (!app.callServerMethod) {
             throw new Error('app.callServerMethod is not defined');
         }
@@ -147,16 +147,20 @@ export class AppDefDriver<T> {
         const createProps = (uri: string) => ({
             callServerMethod(filePath: string, methodName: string, args: unknown[]) {
                 return app.callServerMethod!(
-                    { 
-                        fsApi, 
-                        importModule
-                    }, 
-                    filePath, methodName, args
+                    {
+                        fsApi,
+                        importModule,
+                    },
+                    filePath,
+                    methodName,
+                    args,
                 );
             },
             importModule: this.importModule,
             manifest: this.lastManifest!,
-            onCaughtError() {/**/},
+            onCaughtError() {
+                /**/
+            },
             setUri(_uri: string) {
                 // ToDo: implement
             },
@@ -164,22 +168,22 @@ export class AppDefDriver<T> {
         });
         const unmount = await app.render(container, createProps(uri));
         let lastUri = uri;
-        const rerender = ({uri = '/'}: {uri?: string} = {})=>{
+        const rerender = ({ uri = '/' }: { uri?: string } = {}) => {
             lastUri = uri;
             return app.render(container, createProps(uri));
-        }
+        };
         const manifestListener = () => {
-            void rerender({uri: lastUri});
+            void rerender({ uri: lastUri });
         };
         this.addManifestListener(manifestListener);
         return {
-            dispose: ()=> {
+            dispose: () => {
                 unmount();
                 container.remove();
-                this.removeManifestListener(manifestListener)
+                this.removeManifestListener(manifestListener);
             },
             container,
-            rerender
+            rerender,
         };
     }
     dispose() {
@@ -210,7 +214,7 @@ export class AppDefDriver<T> {
                 stop: () => {
                     listeners.delete(cb);
                 },
-                contents: Promise.resolve(this.fs.readFileSync(filePath, {encoding: 'utf8'}) ?? null),
+                contents: Promise.resolve(this.fs.readFileSync(filePath, { encoding: 'utf8' }) ?? null),
             };
         },
         watchFileExports: (filePath: string, cb) => {
@@ -222,11 +226,11 @@ export class AppDefDriver<T> {
             try {
                 const module = this.moduleSystem.requireModule(filePath);
                 moduleExports = Object.keys(module as Record<string, unknown>);
-            } catch (e){
+            } catch (e) {
                 const errMsg = e instanceof Error ? e.message : String(e);
                 throw new Error(`error requiring module ${filePath}: ${errMsg}`);
             }
-            
+
             return {
                 stop: () => {
                     listeners.delete(cb);
@@ -243,11 +247,11 @@ export class AppDefDriver<T> {
             } catch (error) {
                 errorMessage = error instanceof Error ? error.message : String(error);
             }
-            return { module, errorMessage }
+            return { module, errorMessage };
         };
         const { stop } = this.fsApi.watchFile(filePath, () => {
             this.moduleSystem.moduleCache.delete(filePath);
-            const {module, errorMessage} = requireModule();
+            const { module, errorMessage } = requireModule();
             onModuleChange?.({
                 results: module || null,
                 status: errorMessage ? 'invalid' : 'ready',
@@ -259,7 +263,7 @@ export class AppDefDriver<T> {
             moduleResults: Promise.resolve({
                 status: errorMessage ? 'invalid' : 'ready',
                 results: module || null,
-                errorMessage
+                errorMessage,
             }),
             dispose() {
                 stop();
@@ -278,7 +282,4 @@ export class AppDefDriver<T> {
         }
         return nestedPaths;
     }
-
 }
-
-

--- a/packages/define-remix-app/src/define-remix-app.tsx
+++ b/packages/define-remix-app/src/define-remix-app.tsx
@@ -70,7 +70,7 @@ export default function defineRemixApp({ appPath, routingPattern = 'file' }: IDe
         requestedURI,
         manifest,
         layoutMap,
-    }: IGetNewPageInfoOptions<undefined, RouteModuleInfo> & { layoutMap: Map<string, ParentLayoutWithExtra> }) => {
+    }: IGetNewPageInfoOptions<RouteModuleInfo, undefined> & { layoutMap: Map<string, ParentLayoutWithExtra> }) => {
         const appDir = fsApi.path.join(fsApi.path.dirname(fsApi.appDefFilePath), appPath);
         const routeDir = fsApi.path.join(appDir, 'routes');
         const varNames = new Set<string>();
@@ -191,7 +191,7 @@ export default function defineRemixApp({ appPath, routingPattern = 'file' }: IDe
             },
         };
     };
-    return defineApp<undefined, RouteModuleInfo>({
+    return defineApp<RouteModuleInfo, undefined>({
         App: ({
             manifest,
             importModule,
@@ -199,7 +199,7 @@ export default function defineRemixApp({ appPath, routingPattern = 'file' }: IDe
             uri,
             onCaughtError,
             callServerMethod,
-        }: IReactAppProps<undefined, RouteModuleInfo>) => {
+        }: IReactAppProps<RouteModuleInfo, undefined>) => {
             const uriRef = useRef(uri);
             uriRef.current = uri;
             const { Router, navigate } = useMemo(
@@ -466,7 +466,7 @@ export default function defineRemixApp({ appPath, routingPattern = 'file' }: IDe
                     },
                 );
                 layoutMap = layouts;
-                const initialManifest: IAppManifest<undefined, RouteModuleInfo> = {
+                const initialManifest: IAppManifest<RouteModuleInfo, undefined> = {
                     routes: [],
                     errorRoutes: [],
                     extraData: rootModuleInfo,

--- a/packages/define-remix-app/src/manifest-to-router.tsx
+++ b/packages/define-remix-app/src/manifest-to-router.tsx
@@ -18,7 +18,7 @@ import { createLinksProxy } from './links-proxy';
 type RouteObject = Parameters<typeof createRemixStub>[0][0];
 
 export const manifestToRouter = (
-    manifest: IAppManifest<undefined, RouteModuleInfo>,
+    manifest: IAppManifest<RouteModuleInfo, undefined>,
     requireModule: DynamicImport,
     setUri: (uri: string) => void,
     onCaughtError: ErrorReporter,

--- a/packages/define-remix-app/src/remix-app-utils.ts
+++ b/packages/define-remix-app/src/remix-app-utils.ts
@@ -1,5 +1,12 @@
 import { DynamicRoutePart, PathApi, RouteInfo, RoutingPattern, StaticRoutePart } from '@wixc3/app-core';
 
+export interface RouteModuleInfo {
+    id: string;
+    path: string;
+    file: string;
+    exportNames: string[];
+    children: RouteModuleInfo[];
+}
 export interface ParentLayoutWithExtra {
     layoutModule: string;
     layoutExportName: string;
@@ -80,32 +87,33 @@ export function readableUriToFilePath(
 export const aRoute = (
     routeDirPath: string,
     path: RouteInfo['path'],
+    parentLayouts: RouteInfo['parentLayouts'],
     pageModule: string,
-    extraData: RouteExtraInfo,
     pathApi: PathApi,
-): RouteInfo<RouteExtraInfo> => ({
+    hasGetStaticRoutes: boolean,
+): RouteInfo<undefined> => ({
     path,
     pageModule,
     pageExportName: 'default',
-    parentLayouts: extraData.parentLayouts,
+    parentLayouts,
     pathString: filePathToReadableUri(pageModule.slice(routeDirPath.length + 1), pathApi) || '',
-    extraData,
-    hasGetStaticRoutes: extraData.exportNames.includes('getStaticRoutes'),
+    hasGetStaticRoutes,
+    extraData: undefined,
 });
 export const anErrorRoute = (
     routeDirPath: string,
     path: RouteInfo['path'],
     pageModule: string,
-    extraData: RouteExtraInfo,
+    parentLayouts: RouteInfo['parentLayouts'],
     pathApi: PathApi,
-): RouteInfo<RouteExtraInfo> => ({
+): RouteInfo<undefined> => ({
     path,
     pageModule,
     pageExportName: 'ErrorBoundary',
-    parentLayouts: extraData.parentLayouts,
+    parentLayouts,
     pathString: filePathToReadableUri(pageModule.slice(routeDirPath.length + 1), pathApi) || '',
-    extraData,
-    hasGetStaticRoutes: extraData.exportNames.includes('getStaticRoutes'),
+    extraData: undefined,
+    hasGetStaticRoutes: false,
 });
 export function filePathToURLParts(filePathInRouteDir: string, path: PathApi): string[] {
     const dirStructure = filePathInRouteDir.split(path.sep);

--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -1444,7 +1444,7 @@ const createAppAndDriver = async (
         appPath,
         routingPattern,
     });
-    const driver = new AppDefDriver<undefined, RouteModuleInfo>({
+    const driver = new AppDefDriver<RouteModuleInfo, undefined>({
         app,
         initialFiles,
         evaluatedNodeModules: {
@@ -1459,8 +1459,8 @@ const createAppAndDriver = async (
     return { app, driver, manifest };
 };
 const expectManifest = (
-    manifest: IAppManifest<undefined, RouteModuleInfo>,
-    expected: Partial<IAppManifest<undefined, RouteModuleInfo>>,
+    manifest: IAppManifest<RouteModuleInfo, undefined>,
+    expected: Partial<IAppManifest<RouteModuleInfo, undefined>>,
 ) => {
     const fullExpected = {
         errorRoutes: [],

--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -20,10 +20,12 @@ import {
     clientLoaderWithFallbackPage,
     clientActionPage,
     pageWithLinks,
+    userApiConsumer,
+    userApiPage,
 } from './test-cases/roots';
 import chai, { expect } from 'chai';
 import { IAppManifest, RouteInfo, RoutingPattern } from '@wixc3/app-core';
-import { ParentLayoutWithExtra, RouteExtraInfo } from '../src/remix-app-utils';
+import { ParentLayoutWithExtra, RouteExtraInfo, RouteModuleInfo } from '../src/remix-app-utils';
 import { waitFor } from 'promise-assist';
 import { IDirectoryContents } from '@file-services/types';
 import * as React from 'react';
@@ -51,6 +53,24 @@ const root: ParentLayoutWithExtra = {
     path: '/',
     exportNames: ['Layout', 'default'],
 };
+const rootModuleInfo = (
+    children: RouteModuleInfo[] = [],
+    overrides: Partial<RouteModuleInfo> = {},
+): RouteModuleInfo => ({
+    children,
+    exportNames: ['Layout', 'default'],
+    file: rootPath,
+    id: 'root',
+    path: '/',
+    ...overrides,
+});
+const moduleInfo = ({ id, path, file, exportNames, children }: Partial<RouteModuleInfo>): RouteModuleInfo => ({
+    children: children || [],
+    exportNames: exportNames || ['default'],
+    file: file!,
+    id: id!,
+    path: path!,
+});
 
 describe('define-remix', () => {
     describe('flat routes', () => {
@@ -59,7 +79,8 @@ describe('define-remix', () => {
                 [indexPath]: simpleLayout,
             });
             expectManifest(manifest, {
-                homeRoute: aRoute({ routeId: 'routes/_index', pageModule: indexPath, readableUri: '', path: [] }),
+                extraData: rootModuleInfo([moduleInfo({ id: 'routes/_index', path: '/', file: indexPath })]),
+                homeRoute: aRoute({ pageModule: indexPath, readableUri: '', path: [] }),
             });
         });
         it('manifest for: about.tsx', async () => {
@@ -68,9 +89,9 @@ describe('define-remix', () => {
                 [testedPath]: simpleLayout,
             });
             expectManifest(manifest, {
+                extraData: rootModuleInfo([moduleInfo({ id: 'routes/about', path: '/about', file: testedPath })]),
                 routes: [
                     aRoute({
-                        routeId: 'routes/about',
                         pageModule: testedPath,
                         readableUri: 'about',
                         path: [urlSeg('about')],
@@ -84,6 +105,9 @@ describe('define-remix', () => {
                 [testedPath]: loaderOnly,
             });
             expectManifest(manifest, {
+                extraData: rootModuleInfo([
+                    moduleInfo({ id: 'routes/about', path: '/about', file: testedPath, exportNames: ['loader'] }),
+                ]),
                 routes: [],
             });
         });
@@ -93,9 +117,11 @@ describe('define-remix', () => {
                 [testedPath]: simpleLayout,
             });
             expectManifest(manifest, {
+                extraData: rootModuleInfo([
+                    moduleInfo({ id: 'routes/about/_index', path: '/about', file: testedPath }),
+                ]),
                 routes: [
                     aRoute({
-                        routeId: 'routes/about/_index',
                         pageModule: testedPath,
                         readableUri: 'about/_index',
                         path: [urlSeg('about')],
@@ -113,9 +139,16 @@ describe('define-remix', () => {
             });
 
             expectManifest(manifest, {
+                extraData: rootModuleInfo([
+                    moduleInfo({
+                        id: 'routes/about',
+                        path: '/about',
+                        file: layoutPath,
+                        children: [moduleInfo({ id: 'routes/about/_index', path: '/about', file: testedPath })],
+                    }),
+                ]),
                 routes: [
                     aRoute({
-                        routeId: 'routes/about/_index',
                         pageModule: testedPath,
                         readableUri: 'about/_index',
                         path: [urlSeg('about')],
@@ -142,15 +175,22 @@ describe('define-remix', () => {
                 [aboutUsPath]: simpleLayout,
             });
             expectManifest(manifest, {
+                extraData: rootModuleInfo([
+                    moduleInfo({
+                        id: 'routes/about',
+                        path: '/about',
+                        file: aboutPath,
+                        children: [moduleInfo({ id: 'routes/about/us', path: '/about/us', file: aboutUsPath })],
+                    }),
+                    moduleInfo({ id: 'routes/middle', path: '/middle', file: middlePath }),
+                ]),
                 routes: [
                     aRoute({
-                        routeId: 'routes/about',
                         pageModule: aboutPath,
                         readableUri: 'about',
                         path: [urlSeg('about')],
                     }),
                     aRoute({
-                        routeId: 'routes/about/us',
                         pageModule: aboutUsPath,
                         readableUri: 'about/us',
                         path: [urlSeg('about'), urlSeg('us')],
@@ -165,7 +205,6 @@ describe('define-remix', () => {
                         ],
                     }),
                     aRoute({
-                        routeId: 'routes/middle',
                         pageModule: middlePath,
                         readableUri: 'middle',
                         path: [urlSeg('middle')],
@@ -184,15 +223,21 @@ describe('define-remix', () => {
                 });
 
                 expectManifest(manifest, {
+                    extraData: rootModuleInfo([
+                        moduleInfo({
+                            id: 'routes/about',
+                            path: '/about',
+                            file: aboutPage,
+                            children: [moduleInfo({ id: 'routes/about/us', path: '/about/us', file: aboutUsPage })],
+                        }),
+                    ]),
                     routes: [
                         aRoute({
-                            routeId: 'routes/about',
                             pageModule: aboutPage,
                             readableUri: 'about',
                             path: [urlSeg('about')],
                         }),
                         aRoute({
-                            routeId: 'routes/about/us',
                             pageModule: aboutUsPage,
                             readableUri: 'about/us',
                             path: [urlSeg('about'), urlSeg('us')],
@@ -218,15 +263,25 @@ describe('define-remix', () => {
                 });
 
                 expectManifest(manifest, {
+                    extraData: rootModuleInfo([
+                        moduleInfo({
+                            id: 'routes/about',
+                            path: '/about',
+                            file: aboutPage,
+                        }),
+                        moduleInfo({
+                            id: 'routes/about_/us',
+                            path: '/about/us',
+                            file: aboutUsPage,
+                        }),
+                    ]),
                     routes: [
                         aRoute({
-                            routeId: 'routes/about',
                             pageModule: aboutPage,
                             readableUri: 'about',
                             path: [urlSeg('about')],
                         }),
                         aRoute({
-                            routeId: 'routes/about_/us',
                             pageModule: aboutUsPage,
                             readableUri: 'about_/us',
                             path: [urlSeg('about'), urlSeg('us')],
@@ -247,15 +302,33 @@ describe('define-remix', () => {
                 });
 
                 expectManifest(manifest, {
+                    extraData: rootModuleInfo([
+                        moduleInfo({
+                            id: 'routes/about',
+                            path: '/about',
+                            file: aboutPage,
+                            children: [
+                                moduleInfo({
+                                    id: 'routes/about/us',
+                                    path: '/about/us',
+                                    file: aboutUsPage,
+                                }),
+                                moduleInfo({
+                                    id: 'routes/about/us_/lang',
+                                    path: '/about/us/lang',
+                                    file: aboutUsLangPage,
+                                }),
+                            ],
+                        }),
+                    ]),
+
                     routes: [
                         aRoute({
-                            routeId: 'routes/about',
                             pageModule: aboutPage,
                             readableUri: 'about',
                             path: [urlSeg('about')],
                         }),
                         aRoute({
-                            routeId: 'routes/about/us',
                             pageModule: aboutUsPage,
                             readableUri: 'about/us',
                             path: [urlSeg('about'), urlSeg('us')],
@@ -270,7 +343,6 @@ describe('define-remix', () => {
                             ],
                         }),
                         aRoute({
-                            routeId: 'routes/about/us_/lang',
                             pageModule: aboutUsLangPage,
                             readableUri: 'about/us_/lang',
                             path: [urlSeg('about'), urlSeg('us'), urlSeg('lang')],
@@ -295,9 +367,15 @@ describe('define-remix', () => {
                 });
 
                 expectManifest(manifest, {
+                    extraData: rootModuleInfo([
+                        moduleInfo({
+                            id: 'routes/product/$productId',
+                            path: '/product/:productId',
+                            file: productPage,
+                        }),
+                    ]),
                     routes: [
                         aRoute({
-                            routeId: 'routes/product/$productId',
                             pageModule: productPage,
                             readableUri: 'product/$productId',
                             path: [urlSeg('product'), { kind: 'dynamic', name: 'productId' }],
@@ -313,9 +391,15 @@ describe('define-remix', () => {
                 });
 
                 expectManifest(manifest, {
+                    extraData: rootModuleInfo([
+                        moduleInfo({
+                            id: 'routes/product/($productId)',
+                            path: '/product/:productId',
+                            file: productPage,
+                        }),
+                    ]),
                     routes: [
                         aRoute({
-                            routeId: 'routes/product/($productId)',
                             pageModule: productPage,
                             readableUri: 'product/($productId)',
                             path: [urlSeg('product'), { kind: 'dynamic', name: 'productId', isOptional: true }],
@@ -331,9 +415,15 @@ describe('define-remix', () => {
                 });
 
                 expectManifest(manifest, {
+                    extraData: rootModuleInfo([
+                        moduleInfo({
+                            id: 'routes/product/$',
+                            path: '/product/:$',
+                            file: productPage,
+                        }),
+                    ]),
                     routes: [
                         aRoute({
-                            routeId: 'routes/product/$',
                             pageModule: productPage,
                             readableUri: 'product/$',
                             path: [urlSeg('product'), { kind: 'dynamic', name: '$', isCatchAll: true }],
@@ -348,9 +438,15 @@ describe('define-remix', () => {
                 });
 
                 expectManifest(manifest, {
+                    extraData: rootModuleInfo([
+                        moduleInfo({
+                            id: 'routes/_layout/about',
+                            path: '/about',
+                            file: aboutPage,
+                        }),
+                    ]),
                     routes: [
                         aRoute({
-                            routeId: 'routes/_layout/about',
                             pageModule: aboutPage,
                             readableUri: '_layout/about',
                             path: [urlSeg('about')],
@@ -367,9 +463,22 @@ describe('define-remix', () => {
                 });
 
                 expectManifest(manifest, {
+                    extraData: rootModuleInfo([
+                        moduleInfo({
+                            id: 'routes/_layout',
+                            path: '/',
+                            file: layout,
+                            children: [
+                                moduleInfo({
+                                    id: 'routes/_layout/about',
+                                    path: '/about',
+                                    file: aboutPage,
+                                }),
+                            ],
+                        }),
+                    ]),
                     routes: [
                         aRoute({
-                            routeId: 'routes/_layout/about',
                             pageModule: aboutPage,
                             readableUri: '_layout/about',
                             path: [urlSeg('about')],
@@ -395,9 +504,9 @@ describe('define-remix', () => {
                 [testedPath]: simpleLayout,
             });
             expectManifest(manifest, {
+                extraData: rootModuleInfo([moduleInfo({ id: 'routes/about/index', path: '/about', file: testedPath })]),
                 routes: [
                     aRoute({
-                        routeId: 'routes/about/index',
                         pageModule: testedPath,
                         readableUri: 'about',
                         path: [urlSeg('about')],
@@ -411,9 +520,9 @@ describe('define-remix', () => {
                 [testedPath]: simpleLayout,
             });
             expectManifest(manifest, {
+                extraData: rootModuleInfo([moduleInfo({ id: 'routes/about/route', path: '/about', file: testedPath })]),
                 routes: [
                     aRoute({
-                        routeId: 'routes/about/route',
                         pageModule: testedPath,
                         readableUri: 'about',
                         path: [urlSeg('about')],
@@ -427,9 +536,11 @@ describe('define-remix', () => {
                 [testedPath]: simpleLayout,
             });
             expectManifest(manifest, {
+                extraData: rootModuleInfo([
+                    moduleInfo({ id: 'routes/about/_index/route', path: '/about', file: testedPath }),
+                ]),
                 routes: [
                     aRoute({
-                        routeId: 'routes/about/_index/route',
                         pageModule: testedPath,
                         readableUri: 'about/_index',
                         path: [urlSeg('about')],
@@ -443,9 +554,11 @@ describe('define-remix', () => {
                 [testedPath]: simpleLayout,
             });
             expectManifest(manifest, {
+                extraData: rootModuleInfo([
+                    moduleInfo({ id: 'routes/about/_index/route', path: '/about', file: testedPath }),
+                ]),
                 routes: [
                     aRoute({
-                        routeId: 'routes/about/_index/route',
                         pageModule: testedPath,
                         readableUri: 'about/_index',
                         path: [urlSeg('about')],
@@ -461,9 +574,22 @@ describe('define-remix', () => {
                 [layoutPath]: simpleLayout,
             });
             expectManifest(manifest, {
+                extraData: rootModuleInfo([
+                    moduleInfo({
+                        id: 'routes/about/route',
+                        path: '/about',
+                        file: layoutPath,
+                        children: [
+                            moduleInfo({
+                                id: 'routes/about/_index/route',
+                                path: '/about',
+                                file: testedPath,
+                            }),
+                        ],
+                    }),
+                ]),
                 routes: [
                     aRoute({
-                        routeId: 'routes/about/_index/route',
                         pageModule: testedPath,
                         readableUri: 'about/_index',
                         path: [urlSeg('about')],
@@ -490,15 +616,32 @@ describe('define-remix', () => {
                 [aboutUsPath]: simpleLayout,
             });
             expectManifest(manifest, {
+                extraData: rootModuleInfo([
+                    moduleInfo({
+                        id: 'routes/about/route',
+                        path: '/about',
+                        file: aboutPath,
+                        children: [
+                            moduleInfo({
+                                id: 'routes/about/us/route',
+                                path: '/about/us',
+                                file: aboutUsPath,
+                            }),
+                        ],
+                    }),
+                    moduleInfo({
+                        id: 'routes/middle/route',
+                        path: '/middle',
+                        file: middlePath,
+                    }),
+                ]),
                 routes: [
                     aRoute({
-                        routeId: 'routes/about/route',
                         pageModule: aboutPath,
                         readableUri: 'about',
                         path: [urlSeg('about')],
                     }),
                     aRoute({
-                        routeId: 'routes/about/us/route',
                         pageModule: aboutUsPath,
                         readableUri: 'about/us',
                         path: [urlSeg('about'), urlSeg('us')],
@@ -513,7 +656,6 @@ describe('define-remix', () => {
                         ],
                     }),
                     aRoute({
-                        routeId: 'routes/middle/route',
                         pageModule: middlePath,
                         readableUri: 'middle',
                         path: [urlSeg('middle')],
@@ -537,8 +679,10 @@ describe('define-remix', () => {
                 [indexPath]: simpleLayout,
             });
             expectManifest(manifest, {
+                extraData: rootModuleInfo([moduleInfo({ id: 'routes/_index', path: '/', file: indexPath })], {
+                    exportNames: ['Layout', 'ErrorBoundary', 'default'],
+                }),
                 homeRoute: anyRoute({
-                    routeId: 'routes/_index',
                     pageModule: indexPath,
                     readableUri: '',
                     path: [],
@@ -546,11 +690,9 @@ describe('define-remix', () => {
                 }),
                 errorRoutes: [
                     anErrorRoute({
-                        routeId: 'error',
                         pageModule: rootPath,
                         readableUri: '',
                         path: [],
-                        exportNames: ['Layout', 'ErrorBoundary', 'default'],
                     }),
                 ],
             });
@@ -561,21 +703,25 @@ describe('define-remix', () => {
                 [indexPath]: layoutWithErrorBoundary,
             });
             expectManifest(manifest, {
+                extraData: rootModuleInfo([
+                    moduleInfo({
+                        id: 'routes/_index',
+                        path: '/',
+                        file: indexPath,
+                        exportNames: ['ErrorBoundary', 'default'],
+                    }),
+                ]),
                 homeRoute: aRoute({
-                    routeId: 'routes/_index',
                     pageModule: indexPath,
                     readableUri: '',
                     path: [],
-                    exportNames: ['ErrorBoundary', 'default'],
                 }),
                 errorRoutes: [
                     anErrorRoute({
-                        routeId: 'routes/_index',
                         pageModule: indexPath,
                         readableUri: '',
                         path: [],
                         parentLayouts: [rootLayout, root],
-                        exportNames: ['ErrorBoundary', 'default'],
                     }),
                 ],
             });
@@ -588,23 +734,27 @@ describe('define-remix', () => {
                 [aboutPage]: layoutWithErrorBoundary,
             });
             expectManifest(manifest, {
+                extraData: rootModuleInfo([
+                    moduleInfo({
+                        id: 'routes/about',
+                        path: '/about',
+                        file: aboutPage,
+                        exportNames: ['ErrorBoundary', 'default'],
+                    }),
+                ]),
                 routes: [
                     aRoute({
-                        routeId: 'routes/about',
                         pageModule: aboutPage,
                         readableUri: 'about',
                         path: [urlSeg('about')],
-                        exportNames: ['ErrorBoundary', 'default'],
                     }),
                 ],
                 errorRoutes: [
                     anErrorRoute({
-                        routeId: 'routes/about',
                         pageModule: aboutPage,
                         readableUri: 'about',
                         path: [urlSeg('about')],
                         parentLayouts: [rootLayout, root],
-                        exportNames: ['ErrorBoundary', 'default'],
                     }),
                 ],
             });
@@ -620,10 +770,13 @@ describe('define-remix', () => {
             driver.addOrUpdateFile(testedPath, simpleLayout);
             await waitFor(() =>
                 expectManifest(driver.getManifest()!, {
-                    homeRoute: aRoute({ routeId: 'routes/_index', pageModule: indexPath, readableUri: '', path: [] }),
+                    extraData: rootModuleInfo([
+                        moduleInfo({ id: 'routes/_index', path: '/', file: indexPath }),
+                        moduleInfo({ id: 'routes/about', path: '/about', file: testedPath }),
+                    ]),
+                    homeRoute: aRoute({ pageModule: indexPath, readableUri: '', path: [] }),
                     routes: [
                         aRoute({
-                            routeId: 'routes/about',
                             pageModule: testedPath,
                             readableUri: 'about',
                             path: [urlSeg('about')],
@@ -641,9 +794,9 @@ describe('define-remix', () => {
             driver.addOrUpdateFile(testedPath, simpleLayout);
             await waitFor(() =>
                 expectManifest(driver.getManifest()!, {
+                    extraData: rootModuleInfo([moduleInfo({ id: 'routes/about', path: '/about', file: testedPath })]),
                     routes: [
                         aRoute({
-                            routeId: 'routes/about',
                             pageModule: testedPath,
                             readableUri: 'about',
                             path: [urlSeg('about')],
@@ -663,9 +816,11 @@ describe('define-remix', () => {
                 exportNames: ['default'],
             };
             expectManifest(manifest, {
+                extraData: rootModuleInfo([moduleInfo({ id: 'routes/about', path: '/about', file: testedPath })], {
+                    exportNames: ['default'],
+                }),
                 routes: [
                     anyRoute({
-                        routeId: 'routes/about',
                         pageModule: testedPath,
                         readableUri: 'about',
                         path: [urlSeg('about')],
@@ -677,9 +832,11 @@ describe('define-remix', () => {
             driver.addOrUpdateFile(rootPath, rootWithLayout);
             await waitFor(() =>
                 expectManifest(driver.getManifest()!, {
+                    extraData: rootModuleInfo([moduleInfo({ id: 'routes/about', path: '/about', file: testedPath })], {
+                        exportNames: ['Layout', 'default'],
+                    }),
                     routes: [
                         aRoute({
-                            routeId: 'routes/about',
                             pageModule: testedPath,
                             readableUri: 'about',
                             path: [urlSeg('about')],
@@ -701,11 +858,9 @@ describe('define-remix', () => {
             expect(pageModule).to.eql('/app/routes/about.tsx');
             expect(newPageRoute).to.eql(
                 aRoute({
-                    routeId: 'routes/about',
                     pageModule: '/app/routes/about.tsx',
                     readableUri: 'about',
                     path: [urlSeg('about')],
-                    exportNames: ['meta', 'default'],
                 }),
             );
             expect(newPageSourceCode).to.include('export default');
@@ -723,11 +878,9 @@ describe('define-remix', () => {
             expect(pageModule).to.eql('/app/routes/about/route.tsx');
             expect(newPageRoute).to.eql(
                 aRoute({
-                    routeId: 'routes/about/route',
                     pageModule: '/app/routes/about/route.tsx',
                     readableUri: 'about',
                     path: [urlSeg('about')],
-                    exportNames: ['meta', 'default'],
                 }),
             );
             expect(routingPattern).to.eql('folder(route)');
@@ -744,11 +897,9 @@ describe('define-remix', () => {
             expect(pageModule).to.eql('/app/routes/about/index.tsx');
             expect(newPageRoute).to.eql(
                 aRoute({
-                    routeId: 'routes/about/index',
                     pageModule: '/app/routes/about/index.tsx',
                     readableUri: 'about',
                     path: [urlSeg('about')],
-                    exportNames: ['meta', 'default'],
                 }),
             );
             expect(routingPattern).to.eql('folder(index)');
@@ -765,7 +916,6 @@ describe('define-remix', () => {
             expect(pageModule).to.eql(aboutUsPage);
             expect(newPageRoute).to.eql(
                 aRoute({
-                    routeId: 'routes/about/us',
                     pageModule: aboutUsPage,
                     readableUri: 'about/us',
                     path: [urlSeg('about'), urlSeg('us')],
@@ -778,7 +928,6 @@ describe('define-remix', () => {
                             exportNames: ['default'],
                         },
                     ],
-                    exportNames: ['meta', 'default'],
                 }),
             );
             expect(warningMessage).to.include(parentLayoutWarning('about', 'about_/us'));
@@ -795,7 +944,6 @@ describe('define-remix', () => {
             expect(pageModule).to.eql(aboutUsPage);
             expect(newPageRoute).to.eql(
                 aRoute({
-                    routeId: 'routes/about/_index',
                     pageModule: aboutUsPage,
                     readableUri: 'about/_index',
                     path: [urlSeg('about')],
@@ -808,7 +956,6 @@ describe('define-remix', () => {
                             exportNames: ['default'],
                         },
                     ],
-                    exportNames: ['meta', 'default'],
                 }),
             );
             expect(warningMessage).to.include(parentLayoutWarning('about', 'about_/_index'));
@@ -935,11 +1082,9 @@ describe('define-remix', () => {
             expect(pageModule).to.eql('/app/routes/about2.tsx');
             expect(newPageRoute).to.eql(
                 aRoute({
-                    routeId: 'routes/about2',
                     pageModule: '/app/routes/about2.tsx',
                     readableUri: 'about2',
                     path: [urlSeg('about2')],
-                    exportNames: ['meta', 'default'],
                 }),
             );
             expect(routingPattern).to.eql('file');
@@ -1172,8 +1317,41 @@ describe('define-remix', () => {
 
                 dispose();
             });
-
         });
+        describe('fetchers', () => {
+            const fetcherSuite = (fetcherType: 'page' | 'api') => {
+                it('should load data using fetcher for ' + fetcherType, async () => {
+                    const { driver } = await getInitialManifest({
+                        [rootPath]: rootWithLayout2,
+                        '/app/routes/api.users.tsx': fetcherType === 'page' ? actionPage('Users') : userApiPage,
+                        '/app/routes/contact.$nickname.tsx': userApiConsumer('/api/users'),
+                    });
+
+                    const { dispose, container } = await driver.render({ uri: 'contact/yossi' });
+
+                    await expect(() => container.textContent)
+                        .retry()
+                        .to.include('Layout|App|UserPage|User does not exist');
+
+                    const nameField = container.querySelector('input[name=fullName]') as HTMLInputElement;
+                    const emailField = container.querySelector('input[name=email]') as HTMLInputElement;
+                    const submitButton = container.querySelector('button[type=submit]') as HTMLButtonElement;
+                    nameField.value = 'John Doe';
+                    emailField.value = 'jhon@doe.com';
+                    submitButton.click();
+                    await expect(() => container.textContent)
+                        .retry()
+                        .to.include('Layout|App|UserPage|User exist');
+                    await expect(() => container.textContent)
+                        .retry()
+                        .to.include('User created');
+                    dispose();
+                });
+            };
+            fetcherSuite('page');
+            fetcherSuite('api');
+        });
+
         describe('handle', () => {
             it('exported handled should be available using useMatches', async () => {
                 const aboutUsPath = '/app/routes/about.us.tsx';
@@ -1196,7 +1374,7 @@ describe('define-remix', () => {
             });
         });
 
-        describe('links function', ()=>{
+        describe('links function', () => {
             it('should render links returned by the links function', async () => {
                 const { driver } = await getInitialManifest({
                     [rootPath]: rootWithLayout2,
@@ -1209,10 +1387,9 @@ describe('define-remix', () => {
                     .retry()
                     .to.include('Layout|App|Home');
 
-                const link = container.querySelector('link')
-                expect(link?.getAttribute('href'))
-                    .to.include('some.css');
-              
+                const link = container.querySelector('link');
+                expect(link?.getAttribute('href')).to.include('some.css');
+
                 dispose();
             });
             it('should support having the links function added and removed', async () => {
@@ -1227,24 +1404,21 @@ describe('define-remix', () => {
                     .retry()
                     .to.include('Layout|App|Home');
 
-
-                const link = container.querySelector('link')
+                const link = container.querySelector('link');
                 expect(link).to.equal(null);
 
                 driver.addOrUpdateFile(indexPath, pageWithLinks('HomeUpdated'));
 
-                
                 await expect(() => container.textContent)
                     .retry()
                     .to.include('Layout|App|HomeUpdated');
 
-                const updatedLink = container.querySelector('link')
-                expect(updatedLink?.getAttribute('href'))
-                    .to.include('some.css');
-              
+                const updatedLink = container.querySelector('link');
+                expect(updatedLink?.getAttribute('href')).to.include('some.css');
+
                 dispose();
             });
-        })
+        });
     });
 });
 
@@ -1270,7 +1444,7 @@ const createAppAndDriver = async (
         appPath,
         routingPattern,
     });
-    const driver = new AppDefDriver<RouteExtraInfo>({
+    const driver = new AppDefDriver<undefined, RouteModuleInfo>({
         app,
         initialFiles,
         evaluatedNodeModules: {
@@ -1284,7 +1458,10 @@ const createAppAndDriver = async (
 
     return { app, driver, manifest };
 };
-const expectManifest = (manifest: IAppManifest<RouteExtraInfo>, expected: Partial<IAppManifest<RouteExtraInfo>>) => {
+const expectManifest = (
+    manifest: IAppManifest<undefined, RouteModuleInfo>,
+    expected: Partial<IAppManifest<undefined, RouteModuleInfo>>,
+) => {
     const fullExpected = {
         errorRoutes: [],
         routes: [],
@@ -1294,92 +1471,72 @@ const expectManifest = (manifest: IAppManifest<RouteExtraInfo>, expected: Partia
 };
 
 const anyRoute = ({
-    routeId,
     pageModule,
     pageExportName = 'default',
     readableUri: pathString = '',
     path = [],
     parentLayouts = [],
-    exportNames = ['default'],
     hasGetStaticRoutes = false,
 }: {
-    routeId: string;
     pageModule: string;
     pageExportName?: string;
     readableUri?: string;
     path?: RouteInfo['path'];
     parentLayouts?: RouteExtraInfo['parentLayouts'];
-    exportNames?: string[];
     hasGetStaticRoutes?: boolean;
-}): RouteInfo<RouteExtraInfo> => {
+}): RouteInfo<undefined> => {
     return {
         path,
         pathString,
         pageModule,
         hasGetStaticRoutes,
         pageExportName,
-        extraData: {
-            parentLayouts,
-            routeId,
-            exportNames,
-        },
+        extraData: undefined,
         parentLayouts,
     };
 };
 const aRoute = ({
-    routeId,
     pageModule,
     readableUri: pathString = '',
     path = [],
     parentLayouts = [],
     includeRootLayout = true,
-    exportNames,
     hasGetStaticRoutes = false,
 }: {
-    routeId: string;
     pageModule: string;
     readableUri?: string;
     path?: RouteInfo['path'];
     parentLayouts?: RouteExtraInfo['parentLayouts'];
     includeRootLayout?: boolean;
-    exportNames?: string[];
     hasGetStaticRoutes?: boolean;
-}): RouteInfo<RouteExtraInfo> => {
+}): RouteInfo<undefined> => {
     const expectedParentLayouts = includeRootLayout ? [rootLayout, root, ...parentLayouts] : [root, ...parentLayouts];
     return anyRoute({
-        routeId,
         pageModule,
         readableUri: pathString,
         path,
         parentLayouts: expectedParentLayouts,
-        exportNames,
         hasGetStaticRoutes,
     });
 };
 
 const anErrorRoute = ({
-    routeId,
     pageModule,
     readableUri: pathString = '',
     path = [],
     parentLayouts = [],
-    exportNames,
 }: {
-    routeId: string;
     pageModule: string;
     readableUri?: string;
     path?: RouteInfo['path'];
     parentLayouts?: RouteExtraInfo['parentLayouts'];
-    exportNames?: string[];
 }) => {
     return anyRoute({
-        routeId,
         pageModule,
         readableUri: pathString,
         path,
         parentLayouts,
         pageExportName: 'ErrorBoundary',
-        exportNames,
     });
 };
 

--- a/packages/define-remix-app/test/test-cases/roots.ts
+++ b/packages/define-remix-app/test/test-cases/roots.ts
@@ -78,7 +78,8 @@ export const simpleLayout = transformTsx(`
     }
 `);
 
-export const pageWithLinks =(name: string)=> transformTsx(`
+export const pageWithLinks = (name: string) =>
+    transformTsx(`
     import React from 'react';
     import {
         Outlet,
@@ -197,7 +198,7 @@ export const rootWithBreadCrumbs = transformTsx(
                 Breadcrumbs:
                  <div>
                     {matches.map((match) => (
-                        <div key={match.path}>{match?.handle?.name}!</div>
+                        match?.handle?.name ? <div key={match?.handle?.name}>{match?.handle?.name}!</div> : null
                     ))}
                 </div>
             </div>
@@ -277,7 +278,7 @@ export const loaderAndClientLoaderPage = (name: string, message: string, clientM
     }
 `);
 
-export const clientLoaderWithFallbackPage = (name: string,  clientMessage: string) =>
+export const clientLoaderWithFallbackPage = (name: string, clientMessage: string) =>
     transformTsx(`
     import React from 'react';
     import { Outlet, useLoaderData } from '@remix-run/react';
@@ -388,14 +389,7 @@ export default function ${name}() {
     );
 }
 `);
-
-export const actionPage = (name: string) =>
-    transformTsx(`
-    import React from 'react';
-    import { Outlet, Form, useLoaderData, useActionData, json } from '@remix-run/react';
-    
-
-    const userNames = new Map<string, {
+const userApi = ` const userNames = new Map<string, {
         fullName: string;
         email: string;
     }>();
@@ -428,7 +422,22 @@ export const actionPage = (name: string) =>
             exists: false,
         };
       
-    };
+    };`;
+export const userApiPage = transformTsx(`
+    import React from 'react';
+    import { Outlet, Form,  json ,} from '@remix-run/react';
+    
+
+    ${userApi}
+   
+`);
+
+export const actionPage = (name: string) =>
+    transformTsx(`
+    import React from 'react';
+    import { Outlet, Form, useLoaderData, useActionData, json ,} from '@remix-run/react';
+    
+    ${userApi}
     export default function ${name}() {
         const data = useLoaderData();        
         const actionData = useActionData();
@@ -446,7 +455,35 @@ export const actionPage = (name: string) =>
         </div>;
     }
 `);
+export const userApiConsumer = (apiRoute: string) =>
+    transformTsx(`
+    import React, { useEffect } from 'react';
+    import { Outlet, Form, useFetcher,   } from '@remix-run/react';
 
+    export default function UserPage() {
+    
+        const fetcher = useFetcher();
+        useEffect(()=>{
+        fetcher.load("${apiRoute}");
+        })
+        const data = fetcher.data || {};
+
+        const actionFetcher = useFetcher();
+        const actionData = actionFetcher.data || {};
+        return <div>
+        UserPage|<Outlet />
+
+            <p>{data.exists ? 'User exists' : 'User does not exist'}</p>
+            <actionFetcher.Form method="post" action="${apiRoute}">
+                <input type="text" name="fullName" />
+                <input type="text" name="email" />
+
+                <button type="submit">Send</button>
+            </actionFetcher.Form>
+            <p>{actionData?.message}</p>
+        </div>;
+    }
+`);
 
 export const clientActionPage = (name: string) =>
     transformTsx(`

--- a/packages/define-remix-app/test/test-cases/roots.ts
+++ b/packages/define-remix-app/test/test-cases/roots.ts
@@ -198,7 +198,7 @@ export const rootWithBreadCrumbs = transformTsx(
                 Breadcrumbs:
                  <div>
                     {matches.map((match) => (
-                        match?.handle?.name ? <div key={match?.handle?.name}>{match?.handle?.name}!</div> : null
+                        match?.handle?.name ? <div key={match.handle.name}>{match.handle.name}!</div> : null
                     ))}
                 </div>
             </div>


### PR DESCRIPTION
allowed adding extraData on the root of the manifest
used this extra data for all rendering information
support of API only routes 