### PR TITLE
fix: align manifest generic types to use `unknown`

### DIFF
--- a/packages/app-core/src/define-app-types.ts
+++ b/packages/app-core/src/define-app-types.ts
@@ -87,7 +87,7 @@ export interface FSApi {
     path: PathApi;
 }
 
-export interface IReactApp<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = undefined> {
+export interface IReactApp<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = unknown> {
     /**
      * Should be isomorphic, should return the same result on the server and in a web worker
      * returns the app manifest containing a list of routes for the app.
@@ -162,9 +162,9 @@ export interface IReactApp<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = und
         props: IReactAppProps<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA>,
     ) => Promise<() => void>;
 }
-export interface IAppManifest<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = undefined> {
-    extraData: MANIFEST_EXTRA_DATA;
+export interface IAppManifest<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = unknown> {
     routes: RouteInfo<ROUTE_EXTRA_DATA>[];
+    extraData?: MANIFEST_EXTRA_DATA;
     homeRoute?: RouteInfo<ROUTE_EXTRA_DATA>;
     errorRoutes?: RouteInfo<ROUTE_EXTRA_DATA>[];
 }

--- a/packages/app-core/src/define-app-types.ts
+++ b/packages/app-core/src/define-app-types.ts
@@ -164,8 +164,8 @@ export interface IReactApp<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = unk
 }
 export interface IAppManifest<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = unknown> {
     routes: RouteInfo<ROUTE_EXTRA_DATA>[];
-    extraData?: MANIFEST_EXTRA_DATA;
     homeRoute?: RouteInfo<ROUTE_EXTRA_DATA>;
+    extraData: MANIFEST_EXTRA_DATA;
     errorRoutes?: RouteInfo<ROUTE_EXTRA_DATA>[];
 }
 

--- a/packages/app-core/src/define-app-types.ts
+++ b/packages/app-core/src/define-app-types.ts
@@ -87,7 +87,7 @@ export interface FSApi {
     path: PathApi;
 }
 
-export interface IReactApp<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = unknown> {
+export interface IReactApp<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = undefined> {
     /**
      * Should be isomorphic, should return the same result on the server and in a web worker
      * returns the app manifest containing a list of routes for the app.

--- a/packages/app-core/src/define-app.tsx
+++ b/packages/app-core/src/define-app.tsx
@@ -1,7 +1,7 @@
 import { reactErrorHandledRendering } from '@wixc3/react-board/dist/react-error-handled-render';
 import { IReactApp, OmitReactApp } from './define-app-types';
 
-export function defineApp<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = undefined>(
+export function defineApp<MANIFEST_EXTRA_DATA = unknown, ROUTE_EXTRA_DATA = unknown>(
     input: OmitReactApp<IReactApp<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA>>,
 ): IReactApp<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA> {
     const res: IReactApp<MANIFEST_EXTRA_DATA, ROUTE_EXTRA_DATA> = {


### PR DESCRIPTION
Aligning both generic types for the `IAppManifest` interface  (manifest's `extraData` and route's `extraData`) to be `unknown` when not provided.