### PR TITLE
feat(define-remix-app): export GetStaticRoutes type for better clarity

### DIFF
--- a/packages/define-remix-app/src/define-remix-app.tsx
+++ b/packages/define-remix-app/src/define-remix-app.tsx
@@ -42,6 +42,11 @@ export interface IDefineRemixAppProps {
     routingPattern?: RoutingPattern;
 }
 
+/**
+ * Allows Codux to get the static routes (needed to allow navigation to a dynamic page).
+ */
+export type GetStaticRoutes = () => Promise<string[]>;
+
 export const INVALID_MSGS = {
     homeRouteExists: (routePath: string) => 'Home route already exists at ' + routePath,
     emptyName: 'page name cannot be empty',


### PR DESCRIPTION
This pull request adds and exports a `GetStaticRoutes` type to enhance clarity and type safety in user projects when utilizing the `getStaticRoutes` method.