### PR TITLE
fix(define-remix-app): invalid input with initial underscore

### DIFF
--- a/packages/define-remix-app/src/define-remix-app.tsx
+++ b/packages/define-remix-app/src/define-remix-app.tsx
@@ -105,17 +105,17 @@ export default function defineRemixApp({ appPath, routingPattern = 'file' }: IDe
             })
             .join('.');
         const pageName = toCamelCase(pageFileName);
-        if (!pageName) {
+        if (!pageName && !requestedURI) {
             return {
                 isValid: false,
                 errorMessage: INVALID_MSGS.emptyName,
                 pageModule: '',
                 newPageSourceCode: '',
             };
-        } else if (!pageName[0].match(/[A-Za-z]/)) {
+        } else if (!(pageName[0] || requestedURI[0]).match(/[A-Za-z]/)) {
             return {
                 isValid: false,
-                errorMessage: 'Page names must start with a letter of the alphabet',
+                errorMessage: INVALID_MSGS.initialPageLetter,
                 pageModule: '',
                 newPageSourceCode: '',
             };

--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -1024,14 +1024,17 @@ describe('define-remix', () => {
                     [indexPath]: simpleLayout,
                 });
 
-                const { isValid, errorMessage, pageModule, newPageRoute, newPageSourceCode } =
-                    driver.getNewPageInfo('1st-page');
+                const invalidCases = ['1st-page', '_about'];
+                for (const invalidCase of invalidCases) {
+                    const { isValid, errorMessage, pageModule, newPageRoute, newPageSourceCode } =
+                        driver.getNewPageInfo(invalidCase);
 
-                expect(isValid, 'isValid').to.eql(false);
-                expect(errorMessage, 'error message').to.eql(INVALID_MSGS.initialPageLetter);
-                expect(pageModule, 'page module').to.eql('');
-                expect(newPageSourceCode, 'newPageSourceCode').to.eql('');
-                expect(newPageRoute, 'newPageRoute').to.eql(undefined);
+                    expect(isValid, `isValid ${invalidCase}`).to.eql(false);
+                    expect(errorMessage, `error message ${invalidCase}`).to.eql(INVALID_MSGS.initialPageLetter);
+                    expect(pageModule, `page module ${invalidCase}`).to.eql('');
+                    expect(newPageSourceCode, `newPageSourceCode ${invalidCase}`).to.eql('');
+                    expect(newPageRoute, `newPageRoute ${invalidCase}`).to.eql(undefined);
+                }
             });
             it('should limit route param key', async () => {
                 const { driver } = await getInitialManifest({


### PR DESCRIPTION
This PR fixes an incorrect error message for new page names that start with an underscore (_). 
Previously, entering a name like `_page` would incorrectly trigger the message:

> "Page name cannot be empty." 

Now, the message accurately reflects the input: 

> "Page names must start with a letter of the alphabet."
