### PR TITLE
fix(define-remix-app): render root layout when error boundary is rendered

### DIFF
--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -15,7 +15,13 @@ import {
     userApiConsumer,
     userApiPage,
 } from './test-cases/roots';
-import { pageSource, rootSource as originRootSource, expectRoute, expectLoaderData } from './test-cases/route-builder';
+import {
+    pageSource,
+    rootSource as originRootSource,
+    expectRoute,
+    expectLoaderData,
+    expectRootLayout,
+} from './test-cases/route-builder';
 import chai, { expect } from 'chai';
 import { IAppManifest, RouteInfo, RoutingPattern } from '@wixc3/app-core';
 import { ParentLayoutWithExtra, RouteExtraInfo, RouteModuleInfo } from '../src/remix-app-utils';
@@ -1135,8 +1141,8 @@ describe('define-remix', () => {
 
                 const { dispose, container } = await driver.render({ uri: '404' });
 
-                // ToDo: change to make sure layout is rendered around error
-                await expect(() => container.textContent)
+                await expectRootLayout(container);
+                await expect(() => container.textContent, 'root error boundary')
                     .retry()
                     .to.include('RootComponent error');
 

--- a/packages/define-remix-app/test/test-cases/route-builder.ts
+++ b/packages/define-remix-app/test/test-cases/route-builder.ts
@@ -182,6 +182,10 @@ export const expectRoute = async (root: HTMLElement, pageComponentName: string) 
     const pageRootExpectedAttr = `[data-origin="${pageComponentName}-page-component"]`;
     await expect(() => root.querySelector(pageRootExpectedAttr), `in ${pageComponentName} page`).retry().to.exist;
 };
+export const expectRootLayout = async (root: HTMLElement) => {
+    const rootLayoutExpectedAttr = `[data-origin="root-layout"]`;
+    await expect(() => root.querySelector(rootLayoutExpectedAttr), `root layout rendered`).retry().to.exist;
+};
 export const expectRouteError = async (root: HTMLElement, pageComponentName: string) => {
     const pageRootExpectedAttr = `[data-origin="${pageComponentName}-page-error"]`;
     await expect(() => root.querySelector(pageRootExpectedAttr), `in ${pageComponentName} page error`).retry().to.exist;


### PR DESCRIPTION
This PR makes sure that an `ErrorBoundary` is rendered within the defined `Layout` of the `root` route.