### PR TITLE
feat(codux-ui): pass props and refactor picture to img

### DIFF
--- a/packages/codux-ui/src/image/image.tsx
+++ b/packages/codux-ui/src/image/image.tsx
@@ -11,13 +11,13 @@ import { buildWixImageUrl, getDefaultWixImageAttributes, wixImagePropsAreEqual }
  * @param alt - the alt text for the image
  */
 export const WixImage: React.FC<WixImageProps> = React.memo(function WixImage({
-    className,
     imageId,
     mediaBreakpoints,
     alt,
+    ...imgProps
 }) {
     return (
-        <picture className={className}>
+        <picture>
             {mediaBreakpoints.map(({ minWidth, ...wixMediaAttributes }, index) => {
                 const src = buildWixImageUrl({
                     imageId,
@@ -26,12 +26,12 @@ export const WixImage: React.FC<WixImageProps> = React.memo(function WixImage({
                 return <source key={index} media={`(min-width: ${minWidth}px)`} srcSet={src} />;
             })}
             <img
+                {...imgProps}
                 src={buildWixImageUrl({
                     imageId,
                     ...getDefaultWixImageAttributes(),
                 })}
                 alt={alt ?? 'Image'}
-                className={className}
             />
         </picture>
     );

--- a/packages/codux-ui/src/image/image.tsx
+++ b/packages/codux-ui/src/image/image.tsx
@@ -16,23 +16,35 @@ export const WixImage: React.FC<WixImageProps> = React.memo(function WixImage({
     alt,
     ...imgProps
 }) {
-    return (
-        <picture>
-            {mediaBreakpoints.map(({ minWidth, ...wixMediaAttributes }, index) => {
+    const src = buildWixImageUrl({
+        imageId,
+        ...getDefaultWixImageAttributes(),
+    });
+    const { sizes, srcSet } = mediaBreakpoints
+        .sort((a, b) => {
+            if (a.minWidth === b.minWidth) {
+                return 0;
+            }
+            return a.minWidth > b.minWidth ? 1 : -1;
+        })
+        .reduce(
+            (acc, { minWidth, ...wixMediaAttributes }) => {
                 const src = buildWixImageUrl({
                     imageId,
                     ...wixMediaAttributes,
                 });
-                return <source key={index} media={`(min-width: ${minWidth}px)`} srcSet={src} />;
-            })}
-            <img
-                {...imgProps}
-                src={buildWixImageUrl({
-                    imageId,
-                    ...getDefaultWixImageAttributes(),
-                })}
-                alt={alt ?? 'Image'}
-            />
-        </picture>
-    );
+                return {
+                    srcSet: acc.srcSet
+                        ? `${src} ${wixMediaAttributes.width}w, ${acc.srcSet}`
+                        : `${src} ${wixMediaAttributes.width}w`,
+                    sizes: `(min-width: ${minWidth}px) ${wixMediaAttributes.width}px, ${acc.sizes}`,
+                };
+            },
+            {
+                // responsive design with 100vw as the default size
+                sizes: `100vw`,
+                srcSet: '',
+            },
+        );
+    return <img {...imgProps} srcSet={srcSet} sizes={sizes} src={src} alt={alt ?? 'Image'} />;
 }, wixImagePropsAreEqual);

--- a/packages/codux-ui/src/image/types.ts
+++ b/packages/codux-ui/src/image/types.ts
@@ -32,9 +32,21 @@ export interface MediaBreakPoint {
 }
 
 /**
+ * Properties that are being passed to the img element.
+ * Following properties are being omitted:
+ *
+ * *src* - is being omitted as it is build inside the component based on the imageId
+ *
+ * *srcSet, sizes* - are being omitted because these are configured based on the mediaBreakpoints
+ *
+ * *height, width* - are being omitted as the img is supposed use the Intrinsic size of the image that is loaded
+ */
+type ImgPropsToPass = Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'src' | 'srcSet' | 'sizes' | 'height' | 'width'>;
+
+/**
  * Properties for the Wix image component
  */
-export interface WixImageProps {
+export interface WixImageProps extends ImgPropsToPass {
     /**
      * @format wix-image-id
      * @important
@@ -46,10 +58,6 @@ export interface WixImageProps {
      * @important
      */
     mediaBreakpoints: Array<WixImageAttributes & MediaBreakPoint>;
-    /**
-     * @important
-     */
-    className?: string;
     /**
      * @important
      */


### PR DESCRIPTION
This PR makes sure that most of the `img` props which are not handled by the `WixImage` component itself are passed to the img element.

It also refactors the `picture` use with `source` and `img` element to a purely `img` element usage