### PR TITLE
feat(define-remix-app): handle remix defer

### DIFF
--- a/packages/define-remix-app/src/defer.ts
+++ b/packages/define-remix-app/src/defer.ts
@@ -1,6 +1,6 @@
 import { isDeferredData } from '@remix-run/router';
 import { json } from '@remix-run/node';
-import { serializeResponse } from './remix-app-utils';
+import { CoduxDeferredHeaderKey, serializeResponse } from './remix-app-utils';
 
 export type DeferredResult = {
     __deferred: true;
@@ -40,6 +40,7 @@ export async function tryToSerializeDeferredData(res: unknown) {
                 {} as DeferredResult['deferredKeys'],
             ),
         } as DeferredResult),
+        [{ key: CoduxDeferredHeaderKey, value: 'true' }],
     );
 }
 

--- a/packages/define-remix-app/src/defer.ts
+++ b/packages/define-remix-app/src/defer.ts
@@ -1,0 +1,68 @@
+import { isDeferredData } from '@remix-run/router';
+import { json } from '@remix-run/node';
+import { serializeResponse } from './remix-app-utils';
+
+export type DeferredResult = {
+    __deferred: true;
+    deferredKeys: Record<string, PromiseSettledResult<unknown>>;
+    data: Record<string, unknown>;
+};
+
+export async function tryToSerializeDeferredData(res: unknown) {
+    if (!isDeferredData(res)) {
+        return;
+    }
+    await res.resolveData(new AbortController().signal);
+    return serializeResponse(
+        json({
+            __deferred: true,
+            data: Object.entries(res.data).reduce(
+                (acc, [key, value]) => {
+                    if (res.deferredKeys.includes(key) && isDeferredPromise(value) && value._data) {
+                        acc[key] = value._data;
+                    } else {
+                        acc[key] = value;
+                    }
+                    return acc;
+                },
+                {} as Record<string, unknown>,
+            ),
+            deferredKeys: res.deferredKeys.reduce(
+                (acc, key) => {
+                    const promise = res.data[key] as DeferredPromise;
+                    if (promise._data) {
+                        acc[key] = { status: 'fulfilled', value: '' };
+                    } else {
+                        acc[key] = { status: 'rejected', reason: promise._error };
+                    }
+                    return acc;
+                },
+                {} as Record<string, PromiseSettledResult<unknown>>,
+            ),
+        } as DeferredResult),
+    );
+}
+
+export function isDeferredResult(res: unknown): res is DeferredResult {
+    return typeof res === 'object' && !!res && '__deferred' in res;
+}
+
+export function deserializeDeferredResult({ deferredKeys, data }: DeferredResult) {
+    const result = { ...data };
+    for (const [key, x] of Object.entries(deferredKeys)) {
+        result[key] =
+            x.status === 'fulfilled' ? Promise.resolve(result[key]) : Promise.reject(new Error(String(x.reason)));
+    }
+    return result;
+}
+
+type DeferredPromise = { _data: unknown; _error: unknown };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isDeferredPromise(value: any): value is DeferredPromise {
+    return (
+        value instanceof Promise &&
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+        ((value as any)._data !== undefined || (value as any)._error !== undefined)
+    );
+}

--- a/packages/define-remix-app/src/defer.ts
+++ b/packages/define-remix-app/src/defer.ts
@@ -50,8 +50,13 @@ export function isDeferredResult(res: unknown): res is DeferredResult {
 export function deserializeDeferredResult({ deferredKeys, data }: DeferredResult) {
     const result = { ...data };
     for (const [key, x] of Object.entries(deferredKeys)) {
-        result[key] =
-            x.status === 'fulfilled' ? Promise.resolve(result[key]) : Promise.reject(new Error(String(x.reason)));
+        if (x.status === 'fulfilled') {
+            result[key] = Promise.resolve(result[key]);
+        } else {
+            const rejectedDeferred = Promise.reject(new Error(String(x.reason)));
+            rejectedDeferred.catch(() => {});
+            result[key] = rejectedDeferred;
+        }
     }
     return result;
 }

--- a/packages/define-remix-app/src/manifest-to-router.tsx
+++ b/packages/define-remix-app/src/manifest-to-router.tsx
@@ -1,6 +1,7 @@
 import { DynamicImport, IAppManifest, ErrorReporter, IResults } from '@wixc3/app-core';
 import {
     deserializeResponse,
+    isSerializedDeferredResponse,
     isSerializedResponse,
     RouteModuleInfo,
     SerializedResponse,
@@ -455,6 +456,9 @@ function ErrorPage({
 }
 
 async function tryDecodeResponseJsonValue(response: Response) {
+    if (!isSerializedDeferredResponse(response)) {
+        return;
+    }
     const reader = response.clone().body?.getReader();
     const td = new TextDecoder('utf-8', {});
     let text = '';

--- a/packages/define-remix-app/src/remix-app-utils.ts
+++ b/packages/define-remix-app/src/remix-app-utils.ts
@@ -280,7 +280,10 @@ function getFormData(formData: FormData) {
     });
     return entries;
 }
-export async function serializeResponse(response: Response): Promise<SerializedResponse> {
+export async function serializeResponse(
+    response: Response,
+    headers?: { key: string; value: string }[],
+): Promise<SerializedResponse> {
     const reader = response.body?.getReader();
     let body: string | null = null;
     if (reader) {
@@ -291,7 +294,7 @@ export async function serializeResponse(response: Response): Promise<SerializedR
         _serializedResponse: true,
         status: response.status,
         statusText: response.statusText,
-        headers: getHeaders(response),
+        headers: [...getHeaders(response), ...(headers || [])],
         body,
     };
 }
@@ -306,6 +309,11 @@ export interface SerializedResponse {
 
 export function isSerializedResponse(response: unknown): response is SerializedResponse {
     return (response as SerializedResponse)?._serializedResponse === true;
+}
+
+export const CoduxDeferredHeaderKey = 'codux-remix-deferred';
+export function isSerializedDeferredResponse(response: Response): boolean {
+    return response.headers.has(CoduxDeferredHeaderKey);
 }
 
 export function deserializeResponse(response: SerializedResponse) {

--- a/packages/define-remix-app/src/remix-app-utils.ts
+++ b/packages/define-remix-app/src/remix-app-utils.ts
@@ -312,9 +312,6 @@ export function isSerializedResponse(response: unknown): response is SerializedR
 }
 
 export const CoduxDeferredHeaderKey = 'codux-remix-deferred';
-export function isSerializedDeferredResponse(response: Response): boolean {
-    return response.headers.has(CoduxDeferredHeaderKey);
-}
 
 export function deserializeResponse(response: SerializedResponse) {
     const headers = new Headers();

--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -1234,6 +1234,9 @@ describe('define-remix', () => {
                         `,
                         componentCode: `
                             const { criticalValue, deferredValue, deferredFailValue } = useLoaderData();
+                            if (!deferredValue.then || !deferredFailValue.then) {
+                                throw new Error('expected deferredValue and deferredFailValue to be promises');
+                            }
                             return (
                                 <div>
                                     <div>critical: {criticalValue}</div>

--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -21,6 +21,7 @@ import {
     expectRoute,
     expectLoaderData,
     expectRootLayout,
+    preserveStringAsCode,
 } from './test-cases/route-builder';
 import chai, { expect } from 'chai';
 import { IAppManifest, RouteInfo, RoutingPattern } from '@wixc3/app-core';
@@ -1202,6 +1203,67 @@ describe('define-remix', () => {
                 const { dispose, container } = await driver.render({ uri: 'about' });
 
                 await expectLoaderData(container, 'About', { loaderDataFrom: 'about' });
+
+                dispose();
+            });
+            it('should accept deferred response from loader', async () => {
+                const { driver } = await getInitialManifest({
+                    [rootPath]: rootSource({}),
+                    [aboutPath]: pageSource({
+                        componentName: 'About',
+                        loader: {
+                            criticalValue: 'immediate value',
+                            deferredValue: preserveStringAsCode(
+                                'new Promise(resolve => setTimeout(() => resolve("waited value"), 100))',
+                            ),
+                            deferredFailValue: preserveStringAsCode(
+                                'new Promise((_, reject) => setTimeout(() => reject("boom"), 100))',
+                            ),
+                        },
+                        loaderDefer: true,
+                        imports: [
+                            { specifier: 'react', namedImports: ['Suspense'] },
+                            { specifier: '@remix-run/react', namedImports: ['Await', 'useAsyncError'] },
+                        ],
+
+                        extraModuleCode: `
+                            function DeferredError() {
+                                const err = useAsyncError();
+                                return <div>deferred fail: {err.message}</div>;
+                            }
+                        `,
+                        componentCode: `
+                            const { criticalValue, deferredValue, deferredFailValue } = useLoaderData();
+                            return (
+                                <div>
+                                    <div>critical: {criticalValue}</div>
+                                    <div>
+                                        <Suspense>
+                                            <Await resolve={deferredValue}>
+                                                {resolvedValue => 'deferred: ' + resolvedValue}
+                                            </Await>
+                                        </Suspense>
+                                    </div>
+                                    <div>
+                                        <Suspense>
+                                            <Await resolve={deferredFailValue} errorElement={<DeferredError />}>
+                                                {resolvedValue => 'deferred succeed: ' + resolvedValue}
+                                            </Await>
+                                        </Suspense>
+                                    </div>
+                                </div>
+                            );
+                        `,
+                    }),
+                });
+
+                const { dispose, container } = await driver.render({ uri: 'about' });
+
+                await waitFor(() => {
+                    expect(container.textContent).to.include('critical: immediate value');
+                    expect(container.textContent).to.include('deferred: waited value');
+                    expect(container.textContent).to.include('deferred fail: boom');
+                });
 
                 dispose();
             });

--- a/packages/define-remix-app/test/test-cases/route-builder.ts
+++ b/packages/define-remix-app/test/test-cases/route-builder.ts
@@ -180,7 +180,6 @@ export const pageSource = ({
         moduleCodeDefs.add(`
             export function ErrorBoundary() {
             const error = useRouteError();
-            debugger;
                 return <div data-origin="${componentName}-page-error">${componentName} error</div>;
             }
         `);


### PR DESCRIPTION
This PR adds proper support for Remix's `defer` feature in both `loader` and `action` functions. 

Previously, deferred responses were handled by awaiting promises on the server and passing the resolved, unwrapped data to the client. However, this approach did not align with Remix's intended behavior, which is to pass promises to the client within loader data. Additionally, the existing tests did not verify this behavior.

In this solution, we still await the data on the server, but we now mark it as deferred data, including information about specific fields expected to be deferred. On the client side, these fields are re-wrapped as resolved or rejected promises, ensuring that the client receives them in a deferred state as Remix requires.