### PR TITLE
feat(define-remix-app): Pass 'defineAppMode' to the loader/action via context argument

### DIFF
--- a/packages/define-remix-app/src/define-remix-app.tsx
+++ b/packages/define-remix-app/src/define-remix-app.tsx
@@ -237,6 +237,7 @@ export default function defineRemixApp({ appPath, routingPattern = 'file' }: IDe
                     {
                         params: (args as [DeserializedLoaderArgs])[0].params,
                         request: deserializeRequest((args as [DeserializedLoaderArgs])[0].request),
+                        context: (args as [DeserializedLoaderArgs])[0].context,
                     },
                 ];
             }

--- a/packages/define-remix-app/src/manifest-to-router.tsx
+++ b/packages/define-remix-app/src/manifest-to-router.tsx
@@ -258,7 +258,9 @@ function nonMemoFileToRoute(
     });
 
     const serverLoader: LoaderFunction = async ({ params, request }) => {
-        const res = await callServerMethod(filePath, 'loader', [{ params, request: await serializeRequest(request) }]);
+        const res = await callServerMethod(filePath, 'loader', [
+            { params, request: await serializeRequest(request), context: { defineAppMode: true } },
+        ]);
         if (isSerializedResponse(res)) {
             const desRes = deserializeResponse(res);
             return isDeferredResult(desRes) ? await deserializeDeferredResult(desRes) : desRes;
@@ -267,7 +269,9 @@ function nonMemoFileToRoute(
         }
     };
     const serverAction = async ({ params, request }: ActionFunctionArgs) => {
-        const res = await callServerMethod(filePath, 'action', [{ params, request: await serializeRequest(request) }]);
+        const res = await callServerMethod(filePath, 'action', [
+            { params, request: await serializeRequest(request), context: { defineAppMode: true } },
+        ]);
         const desRes = deserializeResponse(res as SerializedResponse);
         return isDeferredResult(desRes) ? deserializeDeferredResult(desRes) : desRes;
     };

--- a/packages/define-remix-app/src/remix-app-utils.ts
+++ b/packages/define-remix-app/src/remix-app-utils.ts
@@ -263,6 +263,7 @@ export interface SerializedRequest {
 export interface DeserializedLoaderArgs {
     params: Record<string, string>;
     request: SerializedRequest;
+    context: Record<string, unknown>;
 }
 
 function getHeaders(from: Request | Response) {


### PR DESCRIPTION
Pass 'defineAppMode' to the loader/action via context argument to allow app differentiate when it's being run in Codux vs regular flow. This will allow users to mock some functionality that is not supported by the define-app (for example logging in functionality in our e-commerce templates - [draft PR](https://github.com/codux-templates/e-commerce-reclaim/pull/251)).