### PR TITLE
feat(react-board): add global board wrapper

### DIFF
--- a/packages/board-core/src/types.ts
+++ b/packages/board-core/src/types.ts
@@ -128,7 +128,7 @@ export interface IRenderableMetadataBase<HOOKS extends HookMap = HookMap>
      *
      * @returns a cleanup function
      */
-    render: (targetElement: HTMLElement) => Promise<() => void>;
+    render: (targetElement: HTMLElement, Wrapper?: React.FC<React.PropsWithChildren>) => Promise<() => void>;
     /**
      * sets the stage for the renderer.
      * this function has many side effects ( such as effecting window styles and sizes )

--- a/packages/react-board/src/create-board.tsx
+++ b/packages/react-board/src/create-board.tsx
@@ -5,23 +5,20 @@ import type { IReactBoard, OmitReactBoard } from './types';
 export function createBoard(input: OmitReactBoard<IReactBoard>): IReactBoard {
     const res: IReactBoard = createRenderableBase<IReactBoard>({
         ...input,
-        render(target, Wrapper) {
+        render(target, GlobalWrapper) {
             return baseRender(
                 res,
                 async () => {
-                    let element = Wrapper ? (
-                        <Wrapper>
-                            <res.Board />
-                        </Wrapper>
-                    ) : (
-                        <res.Board />
-                    );
+                    let element = <res.Board />;
                     const wrapRenderPlugins = getPluginsWithHooks(res, 'wrapRender');
                     for (const plugin of wrapRenderPlugins) {
                         if (plugin.key.plugin?.wrapRender) {
                             const el = plugin.key.plugin.wrapRender(plugin.props as never, res, element, target);
                             element = el || element;
                         }
+                    }
+                    if (GlobalWrapper) {
+                        element = <GlobalWrapper>{element}</GlobalWrapper>;
                     }
                     return reactErrorHandledRendering(element, target);
                 },

--- a/packages/react-board/src/create-board.tsx
+++ b/packages/react-board/src/create-board.tsx
@@ -5,11 +5,17 @@ import type { IReactBoard, OmitReactBoard } from './types';
 export function createBoard(input: OmitReactBoard<IReactBoard>): IReactBoard {
     const res: IReactBoard = createRenderableBase<IReactBoard>({
         ...input,
-        render(target) {
+        render(target, Wrapper) {
             return baseRender(
                 res,
                 async () => {
-                    let element = <res.Board />;
+                    let element = Wrapper ? (
+                        <Wrapper>
+                            <res.Board />
+                        </Wrapper>
+                    ) : (
+                        <res.Board />
+                    );
                     const wrapRenderPlugins = getPluginsWithHooks(res, 'wrapRender');
                     for (const plugin of wrapRenderPlugins) {
                         if (plugin.key.plugin?.wrapRender) {


### PR DESCRIPTION
This PR allows a wrapper to be passed to the `render` of `createBoard`.

In Codux we look for a functional component in the board-global-setup and will provide it to the render.

