### PR TITLE
fix(define-remix-app): support windows path separator on page creation

### DIFF
--- a/packages/define-remix-app/src/remix-app-utils.ts
+++ b/packages/define-remix-app/src/remix-app-utils.ts
@@ -75,7 +75,7 @@ export function readableUriToFilePath(
     routeDir: string,
     routingPattern: RoutingPattern,
 ): string {
-    const pageFileName = readableUri.replace(/\//g, '.');
+    const pageFileName = readableUri.replace(/[/\\]/g, '.');
 
     return routingPattern === 'folder(route)'
         ? path.join(routeDir, pageFileName, 'route.tsx')

--- a/packages/define-remix-app/test/define-remix.spec.ts
+++ b/packages/define-remix-app/test/define-remix.spec.ts
@@ -1062,7 +1062,7 @@ describe('define-remix', () => {
                 const { driver } = await getInitialManifest({
                     [indexPath]: simpleLayout,
                 });
-                const invalidFsChars = ['\\', ':', '*', '?', '"', "'", '`', '<', '>', '|'];
+                const invalidFsChars = [':', '*', '?', '"', "'", '`', '<', '>', '|'];
                 for (const invalidChar of invalidFsChars) {
                     const { isValid, errorMessage, pageModule, newPageRoute, newPageSourceCode } =
                         driver.getNewPageInfo('about/$param/invalid-' + invalidChar);


### PR DESCRIPTION
On windows, creating a page using `\` as a separator causes Codux to crash.
The issue was in `readableUriToFilePath` which transformed only unix-based separators to `.` and not `\\` as well.