### PR TITLE
fix(react-board): allow mutable react board renderable

### DIFF
--- a/packages/react-board/src/create-board.tsx
+++ b/packages/react-board/src/create-board.tsx
@@ -3,17 +3,18 @@ import { reactErrorHandledRendering } from './react-error-handled-render';
 import type { IReactBoard, OmitReactBoard } from './types';
 
 export function createBoard(input: OmitReactBoard<IReactBoard>): IReactBoard {
-    const res: IReactBoard = createRenderableBase<IReactBoard>({
+    return createRenderableBase<IReactBoard>({
         ...input,
         render(target) {
+            const renderable = this as IReactBoard;
             return baseRender(
-                res,
+                renderable,
                 async () => {
-                    let element = <res.Board />;
-                    const wrapRenderPlugins = getPluginsWithHooks(res, 'wrapRender');
+                    let element = <renderable.Board />;
+                    const wrapRenderPlugins = getPluginsWithHooks(renderable, 'wrapRender');
                     for (const plugin of wrapRenderPlugins) {
                         if (plugin.key.plugin?.wrapRender) {
-                            const el = plugin.key.plugin.wrapRender(plugin.props as never, res, element, target);
+                            const el = plugin.key.plugin.wrapRender(plugin.props as never, renderable, element, target);
                             element = el || element;
                         }
                     }
@@ -23,5 +24,4 @@ export function createBoard(input: OmitReactBoard<IReactBoard>): IReactBoard {
             );
         },
     });
-    return res;
 }

--- a/packages/react-board/src/create-board.tsx
+++ b/packages/react-board/src/create-board.tsx
@@ -5,16 +5,15 @@ import type { IReactBoard, OmitReactBoard } from './types';
 export function createBoard(input: OmitReactBoard<IReactBoard>): IReactBoard {
     return createRenderableBase<IReactBoard>({
         ...input,
-        render(target) {
-            const renderable = this as IReactBoard;
+        render(this: IReactBoard, target) {
             return baseRender(
-                renderable,
+                this,
                 async () => {
-                    let element = <renderable.Board />;
-                    const wrapRenderPlugins = getPluginsWithHooks(renderable, 'wrapRender');
+                    let element = <this.Board />;
+                    const wrapRenderPlugins = getPluginsWithHooks(this, 'wrapRender');
                     for (const plugin of wrapRenderPlugins) {
                         if (plugin.key.plugin?.wrapRender) {
-                            const el = plugin.key.plugin.wrapRender(plugin.props as never, renderable, element, target);
+                            const el = plugin.key.plugin.wrapRender(plugin.props as never, this, element, target);
                             element = el || element;
                         }
                     }

--- a/packages/react-board/test/create-board.spec.tsx
+++ b/packages/react-board/test/create-board.spec.tsx
@@ -50,4 +50,16 @@ describe('create board', () => {
         // await board.render(canvas);
         await expect(board.render(canvas)).not.to.be.rejected;
     });
+
+    it('should allow render of renderable to access state in case of mutation', async () => {
+        const { canvas, cleanup } = board.setupStage();
+        disposables.add(cleanup);
+
+        const mutatedBoard = { ...board, Board: () => 'I was mutated' };
+
+        const cleanupRender = await mutatedBoard.render(canvas);
+        disposables.add(cleanupRender);
+
+        expect(canvas.innerHTML).to.include('I was mutated');
+    });
 });


### PR DESCRIPTION
This PR allows the react board renderable to be mutable.
The render of the react board renderable is now referenceing `this` instead of adding an old reference into it's closure.